### PR TITLE
Add VZVirtioSocketDeviceConfiguration for vsock support

### DIFF
--- a/GhostVMKit/Configuration/VMConfigurationBuilder.swift
+++ b/GhostVMKit/Configuration/VMConfigurationBuilder.swift
@@ -145,6 +145,11 @@ public final class VMConfigurationBuilder {
 
         config.directorySharingDevices = directorySharingDevices
 
+        // Add vsock device for host-guest communication
+        // This enables direct socket communication between host and guest without going through the network stack
+        let socketDevice = VZVirtioSocketDeviceConfiguration()
+        config.socketDevices = [socketDevice]
+
         do {
             try config.validate()
         } catch {


### PR DESCRIPTION
## Summary
- Add `VZVirtioSocketDeviceConfiguration` to VM configuration
- Enable direct socket communication between host and guest without going through the network stack
- Host can connect to guest vsock ports via `VZVirtioSocketDevice` at runtime

## Changes
- Modified `GhostVMKit/Configuration/VMConfigurationBuilder.swift` to add vsock device configuration

## Test Plan
- [x] `make app` builds successfully
- [x] `make test` passes (26 tests)
- [ ] Manual test: Host connects to guest vsock port

Closes #29

:robot: Generated with [Claude Code](https://claude.com/claude-code)