### PR TITLE
Add clipboard sync between host and guest

### DIFF
--- a/GhostVM/Services/ClipboardSyncService.swift
+++ b/GhostVM/Services/ClipboardSyncService.swift
@@ -1,0 +1,213 @@
+import Foundation
+import AppKit
+import Combine
+
+/// Clipboard synchronization modes between host and guest
+public enum ClipboardSyncMode: String, CaseIterable, Codable, Identifiable {
+    case bidirectional
+    case hostToGuest
+    case guestToHost
+    case disabled
+
+    public var id: String { rawValue }
+
+    public var displayName: String {
+        switch self {
+        case .bidirectional: return "Bidirectional"
+        case .hostToGuest: return "Host to Guest"
+        case .guestToHost: return "Guest to Host"
+        case .disabled: return "Disabled"
+        }
+    }
+
+    public var description: String {
+        switch self {
+        case .bidirectional: return "Full sync both directions"
+        case .hostToGuest: return "Can paste into VM, cannot copy out"
+        case .guestToHost: return "Can copy out of VM, cannot paste in"
+        case .disabled: return "No clipboard access"
+        }
+    }
+
+    /// Whether this mode allows sending host clipboard to guest
+    public var allowsHostToGuest: Bool {
+        switch self {
+        case .bidirectional, .hostToGuest:
+            return true
+        case .guestToHost, .disabled:
+            return false
+        }
+    }
+
+    /// Whether this mode allows receiving guest clipboard on host
+    public var allowsGuestToHost: Bool {
+        switch self {
+        case .bidirectional, .guestToHost:
+            return true
+        case .hostToGuest, .disabled:
+            return false
+        }
+    }
+}
+
+/// Service for synchronizing clipboard between host and guest VM
+@MainActor
+public final class ClipboardSyncService: ObservableObject {
+    /// Current sync mode
+    @Published public var syncMode: ClipboardSyncMode = .disabled
+
+    /// Whether the service is actively syncing
+    @Published public private(set) var isActive: Bool = false
+
+    /// Last error encountered during sync
+    @Published public private(set) var lastError: String?
+
+    /// Connection status to the guest
+    @Published public private(set) var isConnected: Bool = false
+
+    private let hostPasteboard = NSPasteboard.general
+    private var lastHostChangeCount: Int = 0
+    private var lastGuestChangeCount: Int = 0
+    private var lastGuestContent: String?
+
+    private var syncTask: Task<Void, Never>?
+    private let pollInterval: TimeInterval = 0.5 // 500ms
+
+    private var guestClient: GhostClient?
+    private let bundlePath: String
+
+    public init(bundlePath: String) {
+        self.bundlePath = bundlePath
+        self.lastHostChangeCount = hostPasteboard.changeCount
+    }
+
+    /// Start clipboard synchronization
+    public func start(client: GhostClient) {
+        guard syncMode != .disabled else {
+            stop()
+            return
+        }
+
+        self.guestClient = client
+        isActive = true
+        lastError = nil
+
+        syncTask?.cancel()
+        syncTask = Task { [weak self] in
+            await self?.runSyncLoop()
+        }
+    }
+
+    /// Stop clipboard synchronization
+    public func stop() {
+        syncTask?.cancel()
+        syncTask = nil
+        isActive = false
+        isConnected = false
+        guestClient = nil
+    }
+
+    /// Set sync mode and restart if active
+    public func setSyncMode(_ mode: ClipboardSyncMode) {
+        let wasActive = isActive
+        let client = guestClient
+
+        syncMode = mode
+
+        if mode == .disabled {
+            stop()
+        } else if wasActive, let client = client {
+            start(client: client)
+        }
+    }
+
+    // MARK: - Private
+
+    private func runSyncLoop() async {
+        while !Task.isCancelled {
+            await syncOnce()
+
+            do {
+                try await Task.sleep(nanoseconds: UInt64(pollInterval * 1_000_000_000))
+            } catch {
+                break
+            }
+        }
+    }
+
+    private func syncOnce() async {
+        guard let client = guestClient, syncMode != .disabled else {
+            return
+        }
+
+        // Check host clipboard for changes
+        if syncMode.allowsHostToGuest {
+            await syncHostToGuest(client: client)
+        }
+
+        // Poll guest clipboard for changes
+        if syncMode.allowsGuestToHost {
+            await syncGuestToHost(client: client)
+        }
+    }
+
+    private func syncHostToGuest(client: GhostClient) async {
+        let currentCount = hostPasteboard.changeCount
+        guard currentCount != lastHostChangeCount else {
+            return
+        }
+
+        lastHostChangeCount = currentCount
+
+        guard let content = hostPasteboard.string(forType: .string) else {
+            return
+        }
+
+        // Avoid echo: don't send if this is what we just received from guest
+        if content == lastGuestContent {
+            return
+        }
+
+        do {
+            try await client.setClipboard(content: content)
+            isConnected = true
+            lastError = nil
+        } catch {
+            lastError = "Failed to send to guest: \(error.localizedDescription)"
+            isConnected = false
+        }
+    }
+
+    private func syncGuestToHost(client: GhostClient) async {
+        do {
+            let response = try await client.getClipboard()
+            isConnected = true
+            lastError = nil
+
+            // Check if guest clipboard changed
+            guard let content = response.content,
+                  content != lastGuestContent else {
+                return
+            }
+
+            lastGuestContent = content
+
+            // Update host clipboard
+            hostPasteboard.clearContents()
+            hostPasteboard.setString(content, forType: .string)
+            lastHostChangeCount = hostPasteboard.changeCount
+
+        } catch GhostClientError.noContent {
+            // No clipboard content on guest - this is normal
+            isConnected = true
+            lastError = nil
+        } catch {
+            lastError = "Failed to get from guest: \(error.localizedDescription)"
+            isConnected = false
+        }
+    }
+
+    deinit {
+        syncTask?.cancel()
+    }
+}

--- a/GhostVM/Services/GhostClient.swift
+++ b/GhostVM/Services/GhostClient.swift
@@ -1,0 +1,365 @@
+import Foundation
+import Virtualization
+
+/// Errors that can occur when communicating with the guest
+public enum GhostClientError: Error, LocalizedError {
+    case notConnected
+    case noContent
+    case invalidResponse(Int)
+    case encodingError
+    case decodingError
+    case connectionFailed(String)
+    case timeout
+
+    public var errorDescription: String? {
+        switch self {
+        case .notConnected:
+            return "Not connected to guest"
+        case .noContent:
+            return "No content available"
+        case .invalidResponse(let code):
+            return "Invalid response from guest (status \(code))"
+        case .encodingError:
+            return "Failed to encode request"
+        case .decodingError:
+            return "Failed to decode response"
+        case .connectionFailed(let reason):
+            return "Connection failed: \(reason)"
+        case .timeout:
+            return "Connection timed out"
+        }
+    }
+}
+
+/// Response from GET /clipboard endpoint
+public struct ClipboardGetResponse: Codable {
+    public let content: String?
+    public let type: String?
+    public let changeCount: Int?
+}
+
+/// Request body for POST /clipboard endpoint
+public struct ClipboardPostRequest: Codable {
+    public let content: String
+    public let type: String
+
+    public init(content: String, type: String = "public.utf8-plain-text") {
+        self.content = content
+        self.type = type
+    }
+}
+
+/// HTTP client for communicating with GhostTools running in the guest VM
+/// Supports both vsock (production) and TCP (development) connections
+@MainActor
+public final class GhostClient {
+    private let virtualMachine: VZVirtualMachine?
+    private let vsockPort: UInt32 = 80
+    private let authToken: String?
+
+    // For development/testing without vsock
+    private let tcpHost: String?
+    private let tcpPort: Int?
+
+    private var urlSession: URLSession?
+
+    /// Initialize client for vsock communication with a running VM
+    public init(virtualMachine: VZVirtualMachine, authToken: String? = nil) {
+        self.virtualMachine = virtualMachine
+        self.authToken = authToken
+        self.tcpHost = nil
+        self.tcpPort = nil
+    }
+
+    /// Initialize client for TCP communication (development/testing)
+    public init(host: String, port: Int, authToken: String? = nil) {
+        self.virtualMachine = nil
+        self.authToken = authToken
+        self.tcpHost = host
+        self.tcpPort = port
+
+        // Create URL session for TCP connections
+        let config = URLSessionConfiguration.ephemeral
+        config.timeoutIntervalForRequest = 5
+        config.timeoutIntervalForResource = 10
+        self.urlSession = URLSession(configuration: config)
+    }
+
+    /// Get current guest clipboard contents
+    public func getClipboard() async throws -> ClipboardGetResponse {
+        if let tcpHost = tcpHost, let tcpPort = tcpPort {
+            return try await getClipboardViaTCP(host: tcpHost, port: tcpPort)
+        } else if let vm = virtualMachine {
+            return try await getClipboardViaVsock(vm: vm)
+        } else {
+            throw GhostClientError.notConnected
+        }
+    }
+
+    /// Set guest clipboard contents
+    public func setClipboard(content: String, type: String = "public.utf8-plain-text") async throws {
+        let request = ClipboardPostRequest(content: content, type: type)
+
+        if let tcpHost = tcpHost, let tcpPort = tcpPort {
+            try await setClipboardViaTCP(host: tcpHost, port: tcpPort, request: request)
+        } else if let vm = virtualMachine {
+            try await setClipboardViaVsock(vm: vm, request: request)
+        } else {
+            throw GhostClientError.notConnected
+        }
+    }
+
+    // MARK: - TCP Implementation (Development)
+
+    private func getClipboardViaTCP(host: String, port: Int) async throws -> ClipboardGetResponse {
+        guard let session = urlSession else {
+            throw GhostClientError.notConnected
+        }
+
+        var urlRequest = URLRequest(url: URL(string: "http://\(host):\(port)/api/v1/clipboard")!)
+        urlRequest.httpMethod = "GET"
+        if let token = authToken {
+            urlRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+
+        let (data, response) = try await session.data(for: urlRequest)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw GhostClientError.invalidResponse(0)
+        }
+
+        if httpResponse.statusCode == 204 {
+            throw GhostClientError.noContent
+        }
+
+        guard httpResponse.statusCode == 200 else {
+            throw GhostClientError.invalidResponse(httpResponse.statusCode)
+        }
+
+        do {
+            let decoder = JSONDecoder()
+            return try decoder.decode(ClipboardGetResponse.self, from: data)
+        } catch {
+            throw GhostClientError.decodingError
+        }
+    }
+
+    private func setClipboardViaTCP(host: String, port: Int, request: ClipboardPostRequest) async throws {
+        guard let session = urlSession else {
+            throw GhostClientError.notConnected
+        }
+
+        var urlRequest = URLRequest(url: URL(string: "http://\(host):\(port)/api/v1/clipboard")!)
+        urlRequest.httpMethod = "POST"
+        urlRequest.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let token = authToken {
+            urlRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+
+        let encoder = JSONEncoder()
+        guard let body = try? encoder.encode(request) else {
+            throw GhostClientError.encodingError
+        }
+        urlRequest.httpBody = body
+
+        let (_, response) = try await session.data(for: urlRequest)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw GhostClientError.invalidResponse(0)
+        }
+
+        guard httpResponse.statusCode == 200 else {
+            throw GhostClientError.invalidResponse(httpResponse.statusCode)
+        }
+    }
+
+    // MARK: - Vsock Implementation (Production)
+
+    private func getClipboardViaVsock(vm: VZVirtualMachine) async throws -> ClipboardGetResponse {
+        let responseData = try await sendHTTPRequest(
+            vm: vm,
+            method: "GET",
+            path: "/api/v1/clipboard",
+            body: nil
+        )
+
+        // Parse HTTP response
+        let (statusCode, body) = try parseHTTPResponse(responseData)
+
+        if statusCode == 204 {
+            throw GhostClientError.noContent
+        }
+
+        guard statusCode == 200 else {
+            throw GhostClientError.invalidResponse(statusCode)
+        }
+
+        guard let body = body else {
+            throw GhostClientError.noContent
+        }
+
+        do {
+            let decoder = JSONDecoder()
+            return try decoder.decode(ClipboardGetResponse.self, from: body)
+        } catch {
+            throw GhostClientError.decodingError
+        }
+    }
+
+    private func setClipboardViaVsock(vm: VZVirtualMachine, request: ClipboardPostRequest) async throws {
+        let encoder = JSONEncoder()
+        guard let body = try? encoder.encode(request) else {
+            throw GhostClientError.encodingError
+        }
+
+        let responseData = try await sendHTTPRequest(
+            vm: vm,
+            method: "POST",
+            path: "/api/v1/clipboard",
+            body: body,
+            contentType: "application/json"
+        )
+
+        let (statusCode, _) = try parseHTTPResponse(responseData)
+
+        guard statusCode == 200 else {
+            throw GhostClientError.invalidResponse(statusCode)
+        }
+    }
+
+    private func sendHTTPRequest(
+        vm: VZVirtualMachine,
+        method: String,
+        path: String,
+        body: Data?,
+        contentType: String? = nil
+    ) async throws -> Data {
+        // Get the socket device from the VM
+        guard let socketDevice = vm.socketDevices.first as? VZVirtioSocketDevice else {
+            throw GhostClientError.connectionFailed("No socket device available")
+        }
+
+        // Connect to the guest on the vsock port
+        let connection: VZVirtioSocketConnection
+        do {
+            connection = try await socketDevice.connect(toPort: vsockPort)
+        } catch {
+            throw GhostClientError.connectionFailed(error.localizedDescription)
+        }
+
+        // Build HTTP request
+        var httpRequest = "\(method) \(path) HTTP/1.1\r\n"
+        httpRequest += "Host: localhost\r\n"
+        httpRequest += "Connection: close\r\n"
+
+        if let token = authToken {
+            httpRequest += "Authorization: Bearer \(token)\r\n"
+        }
+
+        if let contentType = contentType {
+            httpRequest += "Content-Type: \(contentType)\r\n"
+        }
+
+        if let body = body {
+            httpRequest += "Content-Length: \(body.count)\r\n"
+        }
+
+        httpRequest += "\r\n"
+
+        // Convert to data and append body if present
+        var requestData = Data(httpRequest.utf8)
+        if let body = body {
+            requestData.append(body)
+        }
+
+        // Get file descriptor and create FileHandle for reading/writing
+        let fd = connection.fileDescriptor
+        let fileHandle = FileHandle(fileDescriptor: fd, closeOnDealloc: false)
+
+        // Send request
+        do {
+            try fileHandle.write(contentsOf: requestData)
+        } catch {
+            connection.close()
+            throw GhostClientError.connectionFailed("Failed to send request: \(error.localizedDescription)")
+        }
+
+        // Shutdown write side to signal end of request
+        Darwin.shutdown(fd, SHUT_WR)
+
+        // Read response with timeout
+        let responseData: Data
+        do {
+            responseData = try await withTimeout(seconds: 5) {
+                self.readAllData(from: fileHandle)
+            }
+        } catch {
+            connection.close()
+            throw GhostClientError.timeout
+        }
+
+        connection.close()
+        return responseData
+    }
+
+    private nonisolated func readAllData(from handle: FileHandle) -> Data {
+        var result = Data()
+        while true {
+            let chunk = handle.availableData
+            if chunk.isEmpty {
+                break
+            }
+            result.append(chunk)
+        }
+        return result
+    }
+
+    private func parseHTTPResponse(_ data: Data) throws -> (statusCode: Int, body: Data?) {
+        guard let responseString = String(data: data, encoding: .utf8) else {
+            throw GhostClientError.decodingError
+        }
+
+        // Split headers and body
+        let parts = responseString.components(separatedBy: "\r\n\r\n")
+        guard parts.count >= 1 else {
+            throw GhostClientError.decodingError
+        }
+
+        let headerSection = parts[0]
+        let bodyString = parts.count > 1 ? parts[1] : nil
+
+        // Parse status line
+        let headerLines = headerSection.components(separatedBy: "\r\n")
+        guard let statusLine = headerLines.first else {
+            throw GhostClientError.decodingError
+        }
+
+        // Parse status code from "HTTP/1.1 200 OK"
+        let statusParts = statusLine.components(separatedBy: " ")
+        guard statusParts.count >= 2,
+              let statusCode = Int(statusParts[1]) else {
+            throw GhostClientError.decodingError
+        }
+
+        let body = bodyString?.data(using: .utf8)
+
+        return (statusCode, body)
+    }
+
+    private func withTimeout<T>(seconds: Double, operation: @escaping () -> T) async throws -> T {
+        try await withThrowingTaskGroup(of: T.self) { group in
+            group.addTask {
+                return operation()
+            }
+
+            group.addTask {
+                try await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+                throw GhostClientError.timeout
+            }
+
+            let result = try await group.next()!
+            group.cancelAll()
+            return result
+        }
+    }
+}

--- a/GhostVM/SwiftUIDemoApp.swift
+++ b/GhostVM/SwiftUIDemoApp.swift
@@ -85,6 +85,24 @@ struct DemoAppCommands: Commands {
 
             Divider()
 
+            Menu("Clipboard Sync") {
+                ForEach(ClipboardSyncMode.allCases) { mode in
+                    Button {
+                        activeSession?.setClipboardSyncMode(mode)
+                    } label: {
+                        HStack {
+                            Text(mode.displayName)
+                            if activeSession?.clipboardSyncMode == mode {
+                                Image(systemName: "checkmark")
+                            }
+                        }
+                    }
+                }
+            }
+            .disabled(activeSession == nil)
+
+            Divider()
+
             Button("Suspend") {
                 activeSession?.suspend()
             }
@@ -1451,6 +1469,23 @@ struct VMWindowView: View {
         return nil
     }
 
+    private var clipboardSyncIcon: String {
+        switch session.clipboardSyncMode {
+        case .bidirectional:
+            return "arrow.left.arrow.right.circle.fill"
+        case .hostToGuest:
+            return "arrow.right.circle.fill"
+        case .guestToHost:
+            return "arrow.left.circle.fill"
+        case .disabled:
+            return "clipboard"
+        }
+    }
+
+    private var clipboardSyncHelp: String {
+        "Clipboard Sync: \(session.clipboardSyncMode.displayName)"
+    }
+
     var body: some View {
         ZStack {
             App2VMDisplayHost(virtualMachine: session.virtualMachine, isLinux: vm.isLinux, captureSystemKeys: captureSystemKeys)
@@ -1505,6 +1540,25 @@ struct VMWindowView: View {
             }
         }
         .toolbar {
+            ToolbarItem(placement: .automatic) {
+                Menu {
+                    ForEach(ClipboardSyncMode.allCases) { mode in
+                        Button {
+                            session.setClipboardSyncMode(mode)
+                        } label: {
+                            HStack {
+                                Text(mode.displayName)
+                                if session.clipboardSyncMode == mode {
+                                    Image(systemName: "checkmark")
+                                }
+                            }
+                        }
+                    }
+                } label: {
+                    Label("Clipboard Sync", systemImage: clipboardSyncIcon)
+                }
+                .help(clipboardSyncHelp)
+            }
             ToolbarItem(placement: .primaryAction) {
                 Button {
                     session.stop()


### PR DESCRIPTION
## Summary
- Implement clipboard synchronization between GhostVM host and GhostTools guest
- Support four configurable sync modes for security flexibility
- Add UI controls in VM menu and toolbar

## Changes
- **New**: `GhostVM/Services/ClipboardSyncService.swift` - Host-side sync service that polls guest clipboard (500ms interval) and detects host pasteboard changes
- **New**: `GhostVM/Services/GhostClient.swift` - HTTP client supporting both vsock (production) and TCP (development) communication with GhostTools
- **Modified**: `GhostVM/App2VMRuntime.swift` - Integration of clipboard sync with VM session lifecycle
- **Modified**: `GhostVM/SwiftUIDemoApp.swift` - UI controls for clipboard sync mode selection

## Sync Modes
| Mode | Description |
|------|-------------|
| `disabled` | No clipboard access (default for security) |
| `bidirectional` | Full sync both directions |
| `host-to-guest` | Can paste into VM, cannot copy out |
| `guest-to-host` | Can copy out of VM, cannot paste in |

## Test plan
- [ ] Build succeeds with `make app`
- [ ] All tests pass with `make test`
- [ ] VM menu shows Clipboard Sync submenu
- [ ] VM window toolbar shows clipboard icon with mode menu
- [ ] Sync mode setting persists per-VM across app restarts
- [ ] Clipboard sync starts when VM reaches running state
- [ ] Clipboard sync stops when VM stops/suspends

Closes #31

Generated with [Claude Code](https://claude.com/claude-code)