### PR TITLE
Add GhostTools.dmg packaging and Install Guest Tools menu item

### DIFF
--- a/GhostTools/README.txt
+++ b/GhostTools/README.txt
@@ -1,0 +1,37 @@
+GhostTools - Guest Agent for GhostVM
+=====================================
+
+GhostTools is a guest agent that enables enhanced features when running
+inside a GhostVM virtual machine, including:
+
+- Clipboard synchronization between host and guest
+- File transfer support via drag-and-drop
+
+Installation
+------------
+
+1. Copy GhostTools to /usr/local/bin in your guest VM:
+
+   sudo cp /Volumes/GhostTools/GhostTools /usr/local/bin/
+   sudo chmod +x /usr/local/bin/GhostTools
+
+2. Run GhostTools to start the guest agent:
+
+   /usr/local/bin/GhostTools
+
+3. (Optional) To start GhostTools automatically at login, add it to your
+   Login Items in System Settings > General > Login Items.
+
+Usage
+-----
+
+GhostTools runs as a background service listening for requests from the
+host. Once running, features like clipboard sync will work automatically
+when enabled in GhostVM's VM menu.
+
+Requirements
+------------
+
+- macOS 14.0 or later (running as a guest in GhostVM)
+
+For more information, visit: https://github.com/groundwater/GhostVM


### PR DESCRIPTION
## Summary
- Add `make tools` target to build GhostTools using swift build -c release
- Add `make dmg` target to create GhostTools.dmg containing the executable and README.txt
- Add "Install Guest Tools..." menu item in VM menu that copies GhostTools.dmg to the VM's writable shared folder
- Include README.txt with installation instructions for guest users

## Changes
- **Makefile**: New `tools` and `dmg` targets for building and packaging GhostTools
- **GhostTools/README.txt**: Installation instructions for guest users
- **GhostVM/SwiftUIDemoApp.swift**: 
  - Added "Install Guest Tools..." menu item to VM menu
  - Added GuestToolsInstaller class to handle DMG copying and error handling

## Test plan
- [x] `make tools` builds GhostTools successfully
- [x] `make dmg` creates GhostTools.dmg with correct contents
- [x] `make app` still builds GhostVM successfully
- [ ] Menu item appears in VM menu and is disabled when no VM is running
- [ ] Menu item shows error when VM has no writable shared folder
- [ ] Menu item copies DMG to shared folder when VM is running with writable shared folder

Closes #33

---
Generated with [Claude Code](https://claude.ai/code)