### PR TITLE
Auto-attach GhostTools.dmg on first VM start with reinstall option

### DIFF
--- a/GhostVMKit/Core/VMStoredConfig.swift
+++ b/GhostVMKit/Core/VMStoredConfig.swift
@@ -27,6 +27,8 @@ public struct VMStoredConfig: Codable {
     public var guestOSType: String  // "macOS" or "Linux", defaults to "macOS"
     public var efiVariableStorePath: String?  // "NVRAM.bin" for Linux
     public var installerISOPath: String?  // Absolute path to installer ISO (not copied into bundle)
+    // Guest tools installation tracking
+    public var guestToolsInstalled: Bool
 
     public enum CodingKeys: String, CodingKey {
         case version
@@ -53,6 +55,7 @@ public struct VMStoredConfig: Codable {
         case guestOSType
         case efiVariableStorePath
         case installerISOPath
+        case guestToolsInstalled
     }
 
     public init(
@@ -79,7 +82,8 @@ public struct VMStoredConfig: Codable {
         macAddress: String? = nil,
         guestOSType: String = "macOS",
         efiVariableStorePath: String? = nil,
-        installerISOPath: String? = nil
+        installerISOPath: String? = nil,
+        guestToolsInstalled: Bool = false
     ) {
         self.version = version
         self.createdAt = createdAt
@@ -105,6 +109,7 @@ public struct VMStoredConfig: Codable {
         self.guestOSType = guestOSType
         self.efiVariableStorePath = efiVariableStorePath
         self.installerISOPath = installerISOPath
+        self.guestToolsInstalled = guestToolsInstalled
     }
 
     public init(from decoder: Decoder) throws {
@@ -134,6 +139,8 @@ public struct VMStoredConfig: Codable {
         guestOSType = try container.decodeIfPresent(String.self, forKey: .guestOSType) ?? "macOS"
         efiVariableStorePath = try container.decodeIfPresent(String.self, forKey: .efiVariableStorePath)
         installerISOPath = try container.decodeIfPresent(String.self, forKey: .installerISOPath)
+        // Guest tools installation - defaults to false for backwards compatibility
+        guestToolsInstalled = try container.decodeIfPresent(Bool.self, forKey: .guestToolsInstalled) ?? false
     }
 
     public mutating func normalize(relativeTo layout: VMFileLayout) -> Bool {

--- a/GhostVMKit/Session/WindowlessVMSession.swift
+++ b/GhostVMKit/Session/WindowlessVMSession.swift
@@ -78,6 +78,13 @@ public final class WindowlessVMSession: NSObject, VZVirtualMachineDelegate {
                 DispatchQueue.main.async {
                     switch result {
                     case .success:
+                        // Mark guest tools as installed after first successful start
+                        let store = VMConfigStore(layout: self.layout)
+                        if var config = try? store.load(), !config.guestToolsInstalled {
+                            config.guestToolsInstalled = true
+                            config.modifiedAt = Date()
+                            try? store.save(config)
+                        }
                         self.state = .running
                         completion(.success(()))
                     case .failure(let error):
@@ -138,6 +145,10 @@ public final class WindowlessVMSession: NSObject, VZVirtualMachineDelegate {
                             let store = VMConfigStore(layout: self.layout)
                             if var config = try? store.load() {
                                 config.isSuspended = false
+                                // Mark guest tools as installed after first successful start/resume
+                                if !config.guestToolsInstalled {
+                                    config.guestToolsInstalled = true
+                                }
                                 config.modifiedAt = Date()
                                 try? store.save(config)
                             }


### PR DESCRIPTION
## Summary
- Add `guestToolsInstalled` property to `VMStoredConfig` for tracking whether guest tools have been installed
- Auto-attach GhostTools.dmg as a USB mass storage device on the first macOS VM start
- Mark `guestToolsInstalled = true` after VM successfully starts or resumes, so the DMG is only attached once
- Change "Install Guest Tools..." menu item to "Reinstall Guest Tools..." which resets the flag and restarts the VM to trigger re-attachment
- Add `findGhostToolsDMG()` helper in `VMConfigurationBuilder` to locate the DMG in app bundle or build directory

## Test plan
- [ ] Create a new macOS VM and verify GhostTools.dmg appears as a mounted disk on first boot
- [ ] Stop the VM and start it again - verify the DMG is NOT attached on subsequent starts
- [ ] Use "Reinstall Guest Tools..." from VM menu - verify VM restarts and DMG is attached again
- [ ] Verify Linux VMs are not affected (DMG should never be attached)

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)