### PR TITLE
Add log streaming from guest to host console

### DIFF
--- a/GhostTools/Sources/GhostTools/Services/LogService.swift
+++ b/GhostTools/Sources/GhostTools/Services/LogService.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// Service for capturing logs and making them available via HTTP polling
+final class LogService: @unchecked Sendable {
+    static let shared = LogService()
+
+    /// Buffered log entries waiting to be fetched
+    private var buffer: [String] = []
+    private let lock = NSLock()
+    private let maxBufferSize = 500
+
+    private init() {}
+
+    /// Add a log message to the buffer
+    func append(_ message: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        buffer.append(message)
+        // Trim if too large
+        if buffer.count > maxBufferSize {
+            buffer.removeFirst(buffer.count - maxBufferSize)
+        }
+    }
+
+    /// Get and clear all buffered logs
+    func popAll() -> [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        let logs = buffer
+        buffer.removeAll()
+        return logs
+    }
+}
+
+/// Global logging function that prints locally and buffers for host polling
+/// Use this instead of print() throughout GhostTools
+func log(_ message: String) {
+    print(message)
+    LogService.shared.append(message)
+}

--- a/GhostTools/Sources/GhostTools/Services/URLService.swift
+++ b/GhostTools/Sources/GhostTools/Services/URLService.swift
@@ -15,7 +15,7 @@ final class URLService {
         lock.lock()
         defer { lock.unlock() }
         pendingURLs.append(url)
-        print("[URLService] Queued URL: \(url.absoluteString)")
+        log("[URLService] Queued URL: \(url.absoluteString)")
     }
 
     /// Get all pending URLs
@@ -30,7 +30,7 @@ final class URLService {
         lock.lock()
         defer { lock.unlock() }
         pendingURLs.removeAll()
-        print("[URLService] Cleared pending URLs")
+        log("[URLService] Cleared pending URLs")
     }
 
     /// Get and clear pending URLs atomically

--- a/GhostVM/Services/LogPollingService.swift
+++ b/GhostVM/Services/LogPollingService.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// Service that polls guest for logs and prints them to host console
+final class LogPollingService: @unchecked Sendable {
+    private let client: GhostClient
+    private let pollInterval: TimeInterval
+    private var isRunning = false
+    private let lock = NSLock()
+
+    init(client: GhostClient, pollInterval: TimeInterval = 0.5) {
+        self.client = client
+        self.pollInterval = pollInterval
+    }
+
+    func start() {
+        lock.lock()
+        guard !isRunning else {
+            lock.unlock()
+            return
+        }
+        isRunning = true
+        lock.unlock()
+
+        print("[LogPolling] Started")
+
+        DispatchQueue.global(qos: .utility).async { [weak self] in
+            self?.pollLoop()
+        }
+    }
+
+    func stop() {
+        lock.lock()
+        isRunning = false
+        lock.unlock()
+        print("[LogPolling] Stopped")
+    }
+
+    private func pollLoop() {
+        while true {
+            lock.lock()
+            let running = isRunning
+            lock.unlock()
+
+            guard running else { break }
+
+            Task {
+                do {
+                    let logs = try await client.fetchLogs()
+                    for line in logs {
+                        print("[Guest] \(line)")
+                    }
+                } catch {
+                    // Silently ignore errors - guest might not be ready
+                }
+            }
+
+            Thread.sleep(forTimeInterval: pollInterval)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add LogService to buffer logs in guest VM
- Add /api/v1/logs endpoint to fetch buffered logs
- Add LogPollingService to poll guest logs and print to host console
- Replace print() with log() throughout GhostTools

## How It Works

1. **Guest side**: `LogService` captures all log output (via `log()` function) into a circular buffer
2. **Guest side**: `/api/v1/logs` endpoint returns and clears the buffer
3. **Host side**: `LogPollingService` polls the endpoint every 500ms
4. **Host side**: Logs are printed with `[Guest]` prefix for easy identification

## Benefits

- See all guest logs in host terminal alongside host logs
- Single console view for debugging
- Non-blocking HTTP polling over existing vsock connection
- No persistent socket or complex streaming required

## Test Plan

- [ ] Start VM and observe `[Guest]` prefixed logs appearing in host console
- [ ] Verify logs include GhostTools startup messages
- [ ] Verify TunnelServer connection logs appear on host
- [ ] Stop VM and verify log polling stops cleanly

Fixes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)