### PR TITLE
Fix toolbar not reappearing after exiting fullscreen

### DIFF
--- a/GhostVM/App2VMDisplayHost.swift
+++ b/GhostVM/App2VMDisplayHost.swift
@@ -395,9 +395,13 @@ struct App2VMWindowCoordinatorHost: NSViewRepresentable {
             window.toolbar?.isVisible = false
         }
 
-        func windowWillExitFullScreen(_ notification: Notification) {
+        func windowDidExitFullScreen(_ notification: Notification) {
             guard let window = window else { return }
-            window.toolbar?.isVisible = true
+            // Use windowDidExitFullScreen (after animation) + async dispatch
+            // to ensure SwiftUI's toolbar state syncs properly
+            DispatchQueue.main.async {
+                window.toolbar?.isVisible = true
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- Toolbar items (Guest Tools, Clipboard Sync, etc.) were disappearing after entering then exiting fullscreen mode
- Changed from `windowWillExitFullScreen` to `windowDidExitFullScreen` (fires after animation completes)
- Added async dispatch to let SwiftUI sync its toolbar state with the window

## Test plan
- [ ] Open a VM window
- [ ] Enter fullscreen (toolbar should hide for immersive experience)
- [ ] Exit fullscreen (toolbar should reappear)

🤖 Generated with [Claude Code](https://claude.ai/code)