### PR TITLE
Remove basePath — deploy website at root /

### DIFF
--- a/Website/image-loader.ts
+++ b/Website/image-loader.ts
@@ -5,11 +5,5 @@ export default function ghostVMLoader({
   width: number;
   quality?: number;
 }) {
-  // In static export with basePath, unoptimized images don't get the prefix.
-  // This loader ensures all images are served from the correct subdirectory.
-  const basePath = "/ghostvm";
-  if (src.startsWith("/") && !src.startsWith(basePath)) {
-    return `${basePath}${src}`;
-  }
   return src;
 }

--- a/Website/next.config.ts
+++ b/Website/next.config.ts
@@ -2,7 +2,6 @@ import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
   output: "export",
-  basePath: "/ghostvm",
   images: {
     loader: "custom",
     loaderFile: "./image-loader.ts",


### PR DESCRIPTION
## Summary
- Remove `basePath: "/ghostvm"` from `next.config.ts` so the site deploys at `/` instead of `/ghostvm`
- Simplify `image-loader.ts` to a pass-through (no longer needs to prefix image paths)

## Test plan
- [x] `npm run build` succeeds
- [x] No `/ghostvm` prefixes in generated HTML output (`out/`)
- [ ] Verify deployed site loads correctly at root URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)