### PR TITLE
Fix website docs to match codebase

### DIFF
--- a/Website/src/app/docs/building-from-source/page.tsx
+++ b/Website/src/app/docs/building-from-source/page.tsx
@@ -1,0 +1,122 @@
+import type { Metadata } from "next";
+import CodeBlock from "@/components/docs/CodeBlock";
+import Callout from "@/components/docs/Callout";
+import PrevNextNav from "@/components/docs/PrevNextNav";
+import { siteConfig } from "@/config/site";
+
+export const metadata: Metadata = {
+  title: "Building from Source - GhostVM Docs",
+};
+
+export default function BuildingFromSource() {
+  return (
+    <>
+      <h1>Building from Source</h1>
+      <p className="lead">
+        Build GhostVM from source to contribute or run a development version.
+      </p>
+
+      <h2>Prerequisites</h2>
+      <ul>
+        <li>macOS 15+ (Sequoia) on Apple Silicon (M1 or later)</li>
+        <li>Xcode 15+</li>
+        <li>
+          <a href="https://github.com/yonaskolb/XcodeGen">XcodeGen</a>
+        </li>
+      </ul>
+      <CodeBlock language="bash">{`brew install xcodegen`}</CodeBlock>
+
+      <h2>Clone and Build</h2>
+      <CodeBlock language="bash">
+        {`git clone ${siteConfig.repo}
+cd ghostvm
+make app`}
+      </CodeBlock>
+      <p>
+        This generates the Xcode project from <code>project.yml</code> and
+        builds the app. The built app is placed in <code>build/</code>.
+      </p>
+
+      <h2>Code Signing</h2>
+      <p>
+        GhostVM requires the{" "}
+        <code>com.apple.security.virtualization</code> entitlement to use
+        Apple&apos;s Virtualization.framework. The build automatically signs the
+        app with your local <strong>Apple Development</strong> certificate.
+      </p>
+      <p>
+        You need a valid Apple Developer identity in your keychain. Verify you
+        have one with:
+      </p>
+      <CodeBlock language="bash">
+        {`security find-identity -v -p codesigning`}
+      </CodeBlock>
+      <p>
+        Look for a line containing <code>Apple Development</code>. If you
+        don&apos;t have one, open Xcode, go to Settings &rarr; Accounts, and
+        sign in with your Apple ID &mdash; Xcode will create the certificate
+        automatically.
+      </p>
+      <p>
+        To override the signing identity, pass <code>CODESIGN_ID</code>:
+      </p>
+      <CodeBlock language="bash">
+        {`make app CODESIGN_ID="Apple Development: you@example.com (TEAMID)"`}
+      </CodeBlock>
+
+      <Callout variant="warning" title="Ad-hoc signing won't work">
+        Ad-hoc signed builds (<code>-s &quot;-&quot;</code>) cannot use the
+        virtualization entitlement. You must sign with a real Apple Development
+        certificate or the app will crash on launch.
+      </Callout>
+
+      <h2>Make Targets</h2>
+      <table>
+        <thead>
+          <tr>
+            <th>Target</th>
+            <th>Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><code>make app</code></td>
+            <td>Build the GUI app (auto-generates Xcode project)</td>
+          </tr>
+          <tr>
+            <td><code>make cli</code></td>
+            <td>Build the <code>vmctl</code> CLI tool</td>
+          </tr>
+          <tr>
+            <td><code>make generate</code></td>
+            <td>Generate the Xcode project from <code>project.yml</code></td>
+          </tr>
+          <tr>
+            <td><code>make run</code></td>
+            <td>Build and run attached to terminal</td>
+          </tr>
+          <tr>
+            <td><code>make launch</code></td>
+            <td>Build and launch detached</td>
+          </tr>
+          <tr>
+            <td><code>make test</code></td>
+            <td>Run unit tests</td>
+          </tr>
+          <tr>
+            <td><code>make clean</code></td>
+            <td>Remove build artifacts and generated project</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <Callout variant="info" title="XcodeGen">
+        The Xcode project is generated from <code>project.yml</code> using
+        XcodeGen. Do not edit <code>GhostVM.xcodeproj</code> directly &mdash;
+        your changes will be overwritten on the next <code>make generate</code>.
+      </Callout>
+
+      <PrevNextNav currentHref="/docs/building-from-source" />
+    </>
+  );
+}

--- a/Website/src/app/docs/cli/page.tsx
+++ b/Website/src/app/docs/cli/page.tsx
@@ -37,12 +37,12 @@ Options:
 
       <h2>Common Commands</h2>
 
-      <h3>clone</h3>
+      <h3>list</h3>
       <p>
-        Duplicate a VM using APFS copy-on-write. The clone gets a fresh machine
-        identity and MAC address. Near-zero disk overhead.
+        List all VMs in the current root directory with their state. Running VMs
+        show their socket path.
       </p>
-      <CodeBlock language="bash">{`vmctl clone <source-bundle> <new-name>`}</CodeBlock>
+      <CodeBlock language="bash">{`vmctl list`}</CodeBlock>
 
       <h3>start</h3>
       <p>Launch a VM.</p>
@@ -50,7 +50,10 @@ Options:
         {`vmctl start <bundle-path> [options]
 
 Options:
-  --recovery             Boot to Recovery mode`}
+  --headless             Run without a GUI window
+  --shared-folder PATH   Host folder to share with guest
+  --writable             Make shared folder writable (use with --shared-folder)
+  --read-only            Make shared folder read-only (use with --shared-folder)`}
       </CodeBlock>
 
       <h3>stop</h3>
@@ -63,7 +66,15 @@ Options:
 
       <h3>resume</h3>
       <p>Resume from suspended state.</p>
-      <CodeBlock language="bash">{`vmctl resume <bundle-path>`}</CodeBlock>
+      <CodeBlock language="bash">
+        {`vmctl resume <bundle-path> [options]
+
+Options:
+  --headless             Run without a GUI window
+  --shared-folder PATH   Host folder to share with guest
+  --writable             Make shared folder writable (use with --shared-folder)
+  --read-only            Make shared folder read-only (use with --shared-folder)`}
+      </CodeBlock>
 
       <h3>discard-suspend</h3>
       <p>Discard the suspended state so the VM boots fresh.</p>
@@ -76,6 +87,31 @@ Options:
 vmctl snapshot <bundle-path> create <name>
 vmctl snapshot <bundle-path> revert <name>
 vmctl snapshot <bundle-path> delete <name>`}
+      </CodeBlock>
+
+      <h3>socket</h3>
+      <p>
+        Print the Unix socket path for a running VM. Useful for command
+        substitution with other tools.
+      </p>
+      <CodeBlock language="bash">{`vmctl socket <bundle-path>`}</CodeBlock>
+
+      <h3>remote</h3>
+      <p>
+        Execute commands against a running VM via its Host API socket. Requires{" "}
+        <code>--name</code> or <code>--socket</code> to identify the VM.
+      </p>
+      <CodeBlock language="bash">
+        {`vmctl remote --name <VMName> [--json] <subcommand> [args...]
+vmctl remote --socket <path> [--json] <subcommand> [args...]
+
+Subcommands:
+  health                     Check VM connection status
+  exec <command> [args...]   Run a command in the guest
+  clipboard get              Get guest clipboard contents
+  clipboard set <text>       Set guest clipboard contents
+  apps                       List running guest applications
+  interactive                Start interactive REPL`}
       </CodeBlock>
 
       <h2>Examples</h2>
@@ -92,13 +128,18 @@ vmctl snapshot ~/VMs/dev.GhostVM create clean-state
 vmctl snapshot ~/VMs/dev.GhostVM revert clean-state`}
       </CodeBlock>
 
-      <CodeBlock language="bash" title="Clone and automate">
-        {`# Clone an existing workspace
-vmctl clone ~/VMs/dev.GhostVM staging
-vmctl start ~/VMs/staging.GhostVM
+      <CodeBlock language="bash" title="Remote commands">
+        {`# Run a command inside the guest
+vmctl remote --name dev exec uname -a
 
-# Run a command inside the guest
-vmctl remote staging exec 'uname -a'`}
+# Get the guest clipboard
+vmctl remote --name dev clipboard get
+
+# List running apps
+vmctl remote --name dev apps
+
+# Use socket path with command substitution
+vmctl remote --socket $(vmctl socket ~/VMs/dev.GhostVM) interactive`}
       </CodeBlock>
       <PrevNextNav currentHref="/docs/cli" />
     </>

--- a/Website/src/app/docs/getting-started/page.tsx
+++ b/Website/src/app/docs/getting-started/page.tsx
@@ -20,7 +20,6 @@ export default function GettingStarted() {
       <h2>Requirements</h2>
       <ul>
         <li>macOS 15+ (Sequoia) on Apple Silicon (M1 or later)</li>
-        <li>Xcode 15+ and XcodeGen for building from source</li>
       </ul>
 
       <h2>Installation</h2>
@@ -31,13 +30,6 @@ export default function GettingStarted() {
         </a>
         , open it, and drag GhostVM.app into your Applications folder.
       </p>
-      <p>Or build from source:</p>
-      <CodeBlock language="bash">
-        {`brew install xcodegen
-git clone ${siteConfig.repo}
-cd ghostvm
-make app`}
-      </CodeBlock>
 
       <h2>Create your first VM</h2>
 

--- a/Website/src/app/docs/gui-app/page.tsx
+++ b/Website/src/app/docs/gui-app/page.tsx
@@ -126,6 +126,7 @@ export default function GUIApp() {
         <li>IPSW cache location</li>
         <li>IPSW feed URL (for discovering restore images)</li>
         <li>App icon style (System / Light / Dark)</li>
+        <li>Automatic Updates (check for updates, download automatically)</li>
       </ul>
 
       <h2>Restore Images</h2>

--- a/Website/src/app/docs/vm-clone/page.tsx
+++ b/Website/src/app/docs/vm-clone/page.tsx
@@ -75,19 +75,6 @@ export default function VMClone() {
         </tbody>
       </table>
 
-      <h2>CLI Usage</h2>
-      <CodeBlock language="bash">
-        {`vmctl clone <source-bundle> <new-name>
-
-# Example
-vmctl clone ~/VMs/dev.GhostVM staging
-→ Cloned to ~/VMs/staging.GhostVM (APFS copy-on-write)`}
-      </CodeBlock>
-      <p>
-        The clone is created in the same parent directory as the source. The
-        new name must not already exist at that location.
-      </p>
-
       <h2>GUI Usage</h2>
       <p>
         Right-click any stopped VM in the main window and select{" "}

--- a/Website/src/lib/docs-nav.ts
+++ b/Website/src/lib/docs-nav.ts
@@ -31,6 +31,7 @@ export const docsNav: NavItem[] = [
   { title: "GhostTools", href: "/docs/ghosttools" },
   { title: "Host API", href: "/docs/host-api" },
   { title: "Architecture", href: "/docs/architecture" },
+  { title: "Building from Source", href: "/docs/building-from-source" },
 ];
 
 export function flattenNav(items: NavItem[]): NavItem[] {

--- a/macOS/GhostVM/vmctl/CLI.swift
+++ b/macOS/GhostVM/vmctl/CLI.swift
@@ -470,18 +470,6 @@ Remote flags:
 
 Remote subcommands (use 'vmctl remote --help' for full details):
   health                                      Check VM connection
-  screenshot [-o file] [--elements]           Capture VM screen
-  pointer <left|right|middle|double>click     Click at element or coords
-  pointer drag X1 Y1 -- X2 Y2                Drag between points
-  pointer scroll X Y --dy N [--dx N]          Scroll at position
-  input type <text> | key [--meta] <key>      Type text or key combos
-  launch|activate <bundleId>                  Launch or activate app
-  a11y [--front|--all|--app B] [--depth N]    Accessibility tree
-  a11y focused | elements                     Focused element / interactive list
-  a11y click <label> [--role R]               Click element by label
-  a11y action <label> --action AXFoo          Perform any AX action
-  a11y menu <item1> <item2>...                Trigger menu item
-  a11y type <value> [--label L]               Set field value
   exec <command> [args...]                    Run command in guest
   clipboard get | set <text>                  Guest clipboard
   apps                                        List running apps
@@ -504,14 +492,9 @@ Examples:
   vmctl socket ~/VMs/sandbox.GhostVM                   # Get socket path for running VM
   vmctl remote --socket $(vmctl socket Aria) interactive  # Use with command substitution
   vmctl remote --name MyVM health
-  vmctl remote --name MyVM screenshot --elements -o /tmp/screen.png
-  vmctl remote --name MyVM pointer leftclick --element 5
-  vmctl remote --name MyVM pointer doubleclick --element 5
-  vmctl remote --name MyVM input type "hello world"
-  vmctl remote --name MyVM a11y --front --depth 3
-  vmctl remote --name MyVM a11y elements
-  vmctl remote --name MyVM a11y click "OK" --role AXButton
-  vmctl remote --name MyVM a11y menu File "New Window"
+  vmctl remote --name MyVM exec ls -la
+  vmctl remote --name MyVM clipboard get
+  vmctl remote --name MyVM apps
   vmctl remote --name MyVM interactive
 
 Notes:


### PR DESCRIPTION
## Summary
- **host-api**: Rewrote wire protocol (HTTP/1.1, not newline-delimited JSON), fixed socket path format, removed 6 non-existent endpoints, added 8 working endpoints, replaced broken socat/Python examples with curl and proper HTTP examples
- **cli**: Removed non-existent `clone` command, fixed `start`/`resume` options, added `list`, `socket`, `remote` commands, fixed `--name` flag syntax in examples
- **vm-clone**: Removed non-existent CLI clone section (cloning is GUI-only)
- **gui-app**: Added Automatic Updates to Settings list
- **getting-started**: Removed build-from-source instructions (separate concern)
- **building-from-source**: New dedicated page with prerequisites, clone/build steps, code signing requirements, and make targets table
- **CLI.swift**: Removed 12 stale computer-use subcommands from `showHelp()` that no longer exist in `RemoteCommand.dispatchSubcommand()`

## Test plan
- [x] `npm run build` passes with no errors
- [ ] Visually check each modified page renders correctly in dev server
- [ ] Cross-reference documented endpoints against `HostAPIService.swift`
- [ ] Cross-reference documented CLI commands against `CLI.swift` and `RemoteCommand.swift`

🤖 Generated with [Claude Code](https://claude.com/claude-code)