### PR TITLE
Fix clipboard prompt reappearing after dismissal

### DIFF
--- a/macOS/GhostVMHelper/main.swift
+++ b/macOS/GhostVMHelper/main.swift
@@ -893,6 +893,7 @@ final class HelperAppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate
                 return event
             }
             // Auto-dismiss (implicit deny) when user interacts with the VM
+            self.lastPromptedClipboardChangeCount = NSPasteboard.general.changeCount
             self.helperToolbar?.closeClipboardPermissionPopover()
             self.removeClipboardAutoDismissMonitor()
             return event


### PR DESCRIPTION
## Summary
- When the clipboard permission popover is dismissed by clicking away (rather than choosing Deny/Once/Always), the prompt reappeared on every subsequent window focus for the same clipboard content
- Root cause: the auto-dismiss monitor closed the popover but didn't update `lastPromptedClipboardChangeCount`, which all three button handlers set to prevent re-prompting
- Fix: set `lastPromptedClipboardChangeCount` in the auto-dismiss path, matching the explicit Deny behavior

## Test plan
- [ ] Copy text on host, focus VM window — clipboard prompt appears
- [ ] Click inside the VM to dismiss (don't click Deny/Once/Always)
- [ ] Switch away and back — prompt should NOT reappear for same content
- [ ] Copy new text on host, focus VM — prompt SHOULD appear (new content)

🤖 Generated with [Claude Code](https://claude.com/claude-code)