### PR TITLE
Move DEVELOPMENT_TEAM to .env for portable code signing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+# Build directory (use local path if working on a shared/network volume)
+# BUILD_DIR=/tmp/ghostvm-build
+
+# Code signing team ID (find yours: `security find-identity -v -p codesigning`)
+DEVELOPMENT_TEAM=
+
+# Notarization credentials for `make dist`
+NOTARY_APPLE_ID=
+NOTARY_TEAM_ID=
+NOTARY_PASSWORD=

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ GHOSTTOOLS_SIGN_ID ?= $(CODESIGN_ID)
 # Xcode project settings (generated via xcodegen)
 XCODE_PROJECT = macOS/GhostVM.xcodeproj
 XCODE_CONFIG ?= Release
-BUILD_DIR = build/xcode
+BUILD_DIR ?= build/xcode
 APP_NAME = GhostVM
 
 .PHONY: all cli app clean help run launch generate test framework dist tools debug-tools dmg ghosttools-icon ghostvm-icon debug website website-build sparkle-tools sparkle-sign capture composite screenshots bump check-version
@@ -474,6 +474,7 @@ help:
 	@echo "  make clean    - Remove build artifacts and generated project"
 	@echo ""
 	@echo "Variables:"
+	@echo "  DEVELOPMENT_TEAM - Apple Developer team ID (via .env file, see .env.example)"
 	@echo "  CODESIGN_ID   - Code signing identity (default: Apple Development)"
 	@echo "  XCODE_CONFIG  - Xcode build configuration (default: Release)"
 	@echo "  VERSION       - Version for DMG (default: git describe)"

--- a/macOS/project.yml
+++ b/macOS/project.yml
@@ -40,7 +40,7 @@ targets:
           - "@loader_path/../Frameworks"
         CODE_SIGN_STYLE: Automatic
         CODE_SIGN_IDENTITY: "Apple Development"
-        DEVELOPMENT_TEAM: 3FGZQE8AW3
+        DEVELOPMENT_TEAM: ${DEVELOPMENT_TEAM}
         ENABLE_HARDENED_RUNTIME: YES
 
   vmctl:
@@ -61,7 +61,7 @@ targets:
         CODE_SIGN_ENTITLEMENTS: GhostVM/entitlements.plist
         CODE_SIGN_STYLE: Automatic
         CODE_SIGN_IDENTITY: "Apple Development"
-        DEVELOPMENT_TEAM: 3FGZQE8AW3
+        DEVELOPMENT_TEAM: ${DEVELOPMENT_TEAM}
         ENABLE_HARDENED_RUNTIME: YES
         SWIFT_INCLUDE_PATHS: "$(SRCROOT)/GhostVM/vmctl/CEditLine"
         OTHER_LDFLAGS:
@@ -99,7 +99,7 @@ targets:
         CODE_SIGN_ENTITLEMENTS: GhostVMHelper/entitlements.plist
         CODE_SIGN_STYLE: Automatic
         CODE_SIGN_IDENTITY: "Apple Development"
-        DEVELOPMENT_TEAM: 3FGZQE8AW3
+        DEVELOPMENT_TEAM: ${DEVELOPMENT_TEAM}
         ENABLE_HARDENED_RUNTIME: YES
         LD_RUNPATH_SEARCH_PATHS:
           - "@executable_path/../Frameworks"
@@ -143,7 +143,7 @@ targets:
         CODE_SIGN_ENTITLEMENTS: GhostVM/entitlements.plist
         CODE_SIGN_STYLE: Automatic
         CODE_SIGN_IDENTITY: "Apple Development"
-        DEVELOPMENT_TEAM: 3FGZQE8AW3
+        DEVELOPMENT_TEAM: ${DEVELOPMENT_TEAM}
         ENABLE_HARDENED_RUNTIME: YES
         GENERATE_INFOPLIST_FILE: NO
         LD_RUNPATH_SEARCH_PATHS: "@executable_path/../Frameworks"


### PR DESCRIPTION
## Summary
- Replace hardcoded `DEVELOPMENT_TEAM: 3FGZQE8AW3` in `project.yml` with `${DEVELOPMENT_TEAM}` env var interpolation (4 targets)
- Add `.env.example` for onboarding (committed to git; `.env` itself is gitignored)
- Make `BUILD_DIR` overridable (`?=`) so shared/network volumes can redirect builds to a local path that supports symlinks
- Document `DEVELOPMENT_TEAM` in `make help` output

## Test plan
- [ ] Copy `.env.example` to `.env` and fill in your team ID
- [ ] `make clean && make generate` — verify project generates without errors
- [ ] `make test` — verify tests build and run with your team ID
- [ ] `make debug` — verify debug build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)