### PR TITLE
Fix URL permission popover z-order above port forward notifications

### DIFF
--- a/macOS/GhostVMHelper/URLPermissionPanel.swift
+++ b/macOS/GhostVMHelper/URLPermissionPanel.swift
@@ -28,6 +28,11 @@ final class URLPermissionPanel: NSObject, NSPopoverDelegate {
 
         popover.contentViewController = vc
         popover.show(relativeTo: positioningRect, of: positioningView, preferredEdge: preferredEdge)
+
+        // Set custom window level to appear above informational popovers (level 0)
+        // but below system-wide floating windows (level 3)
+        vc.view.window?.level = NSWindow.Level(rawValue: NSWindow.Level.normal.rawValue + 1)
+
         self.popover = popover
     }
 


### PR DESCRIPTION
## Summary
- Sets custom window level (1) on URL permission popovers to ensure they appear above port forward notifications (level 0)
- Prevents notification from obscuring URL prompt action buttons during signin workflows

## Problem
During signin workflows (e.g., codex/claude), GhostVM shows both URL permission prompts and port forward notifications as NSPopovers. When the port forward notification appears second, it obscures the URL prompt's action buttons, preventing the user from clicking "Open" or "Deny".

## Solution
Set the URL permission popover to window level 1 (via `vc.view.window?.level`) immediately after showing. This ensures:
- ✅ URL prompts appear above port forward notifications (level 0)
- ✅ Still below system-wide floating windows (level 3)
- ✅ Action buttons remain clickable regardless of timing

## Files Changed
- `macOS/GhostVMHelper/URLPermissionPanel.swift` - Added window level setting after `popover.show()`

## Test Plan
- [x] Build succeeds without errors
- [ ] Launch VM and trigger signin flow that generates both URL prompts and port forward notifications
- [ ] Verify URL prompt appears on top when port forward notification shows second
- [ ] Verify all three buttons (Deny, Open, Always) remain clickable
- [ ] Verify popover behavior is preserved (applicationDefined, doesn't auto-dismiss)

🤖 Generated with [Claude Code](https://claude.com/claude-code)