### PR TITLE
Fix no-op Stop action in VM context menu

### DIFF
--- a/macOS/GhostVM/SwiftUIDemoApp.swift
+++ b/macOS/GhostVM/SwiftUIDemoApp.swift
@@ -1816,6 +1816,8 @@ struct VMContextMenu: View {
         let lowerStatus = vm.status.lowercased()
         let isRunning = lowerStatus.contains("running") || lowerStatus.contains("starting") || lowerStatus.contains("stopping")
         let isSuspended = lowerStatus.contains("suspended")
+        let canSuspend = lowerStatus.contains("running")
+        let canShutDown = lowerStatus.contains("running")
 
         // Show Install for macOS VMs that need installation
         if vm.needsInstall {
@@ -1835,11 +1837,15 @@ struct VMContextMenu: View {
         }
         .disabled(vm.needsInstall || isRunning)
 
-        Button("Stop") {
-            // VM stop is coordinated by closing the VM window; for now this
-            // entry is present but handled via the window close behavior.
+        Button("Suspend") {
+            App2VMSessionRegistry.shared.session(for: vm.bundlePath)?.suspend()
         }
-        .disabled(!isRunning)
+        .disabled(!canSuspend)
+
+        Button("Shut Down") {
+            App2VMSessionRegistry.shared.session(for: vm.bundlePath)?.stop()
+        }
+        .disabled(!canShutDown)
 
         Button("Terminate") {
             requestTerminate()


### PR DESCRIPTION
## Problem
`Stop` in the VM context menu was a no-op, so clicking it did nothing.

## Changes
- Removed the non-functional `Stop` menu item.
- Added `Suspend` to trigger the active VM session suspend action.
- Added `Shut Down` to trigger graceful shutdown via the active VM session.
- Kept both actions disabled unless the VM is currently running.

## Why this approach
- Matches existing VM command language (`Suspend`, `Shut Down`, `Terminate`).
- Avoids exposing a broken action.
- Uses already-existing runtime session controls instead of introducing new stop logic.

## Verification
- Built app target successfully:
  - `xcodebuild build -project macOS/GhostVM.xcodeproj -scheme GhostVM -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO`
- Ran targeted unit tests:
  - `xcodebuild test -project macOS/GhostVM.xcodeproj -scheme GhostVMTests -destination 'platform=macOS' -only-testing:GhostVMTests/InitOptionsTests`

Fixes #107
