### PR TITLE
Fix terminate confirmation dialog to attach to VM window

### DIFF
--- a/macOS/GhostVMHelper/main.swift
+++ b/macOS/GhostVMHelper/main.swift
@@ -513,9 +513,18 @@ final class HelperAppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate
         alert.addButton(withTitle: "Cancel")
         alert.buttons[0].hasDestructiveAction = true
 
-        let response = alert.runModal()
-        if response == .alertFirstButtonReturn {
-            terminateVM()
+        guard let window else {
+            let response = alert.runModal()
+            if response == .alertFirstButtonReturn {
+                terminateVM()
+            }
+            return
+        }
+
+        alert.beginSheetModal(for: window) { [weak self] response in
+            if response == .alertFirstButtonReturn {
+                self?.terminateVM()
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- prioritize and fix issue #89 (`prio/P1`)
- present the terminate confirmation as a sheet attached to the VM window
- keep a `runModal()` fallback if no window is available

## Validation
- `xcodebuild -project macOS/GhostVM.xcodeproj -scheme GhostVMHelper -configuration Debug -derivedDataPath build/xcode build` (succeeds)

Closes #89
