### PR TITLE
Fix GhostTools install CTA not appearing in helper toolbar

### DIFF
--- a/macOS/GhostVMHelper/HelperToolbar.swift
+++ b/macOS/GhostVMHelper/HelperToolbar.swift
@@ -264,6 +264,7 @@ final class HelperToolbar: NSObject, NSToolbarDelegate, NSMenuDelegate, PortForw
 
     func toolbarDefaultItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
         [
+            ItemID.guestToolsStatus,
             ItemID.iconChooser,
             ItemID.portForwards,
             ItemID.sharedFolders,
@@ -279,6 +280,7 @@ final class HelperToolbar: NSObject, NSToolbarDelegate, NSMenuDelegate, PortForw
 
     func toolbarAllowedItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
         [
+            ItemID.guestToolsStatus,
             ItemID.iconChooser,
             ItemID.portForwards,
             ItemID.sharedFolders,
@@ -295,6 +297,8 @@ final class HelperToolbar: NSObject, NSToolbarDelegate, NSMenuDelegate, PortForw
 
     func toolbar(_ toolbar: NSToolbar, itemForItemIdentifier itemIdentifier: NSToolbarItem.Identifier, willBeInsertedIntoToolbar flag: Bool) -> NSToolbarItem? {
         switch itemIdentifier {
+        case ItemID.guestToolsStatus:
+            return makeGuestToolsItem()
         case ItemID.iconChooser:
             return makeIconChooserItem()
         case ItemID.portForwards:


### PR DESCRIPTION
## Summary
Issue prioritized: #104 (`prio/P1`) because it is the highest-priority open issue in the tracker.

This change wires the Guest Tools status item into the helper toolbar model so the install CTA can actually surface when `ghostTools = notInstalled`.

## Changes
- Added `guestToolsStatus` to default toolbar item identifiers
- Added `guestToolsStatus` to allowed toolbar item identifiers
- Added `guestToolsStatus` case in toolbar item factory switch to build the item

## Validation
- `xcodebuild -scheme GhostVMHelper -configuration Debug -sdk macosx build`

## Notes
- `GhostVMKit` scheme is not configured for `test` action from CLI
- `GhostVM` scheme test plan currently excludes `GhostVMTests`

Fixes #104
