### PR TITLE
Fix default VM naming and Create dialog start directory

### DIFF
--- a/macOS/GhostVM/SavePanelAdapter.swift
+++ b/macOS/GhostVM/SavePanelAdapter.swift
@@ -3,7 +3,11 @@ import AppKit
 import UniformTypeIdentifiers
 
 enum SavePanelAdapter {
-    static func chooseVMBundleURL(suggestedName: String, completion: @MainActor @escaping (URL?) -> Void) {
+    static func chooseVMBundleURL(
+        suggestedName: String,
+        initialDirectoryURL: URL? = nil,
+        completion: @MainActor @escaping (URL?) -> Void
+    ) {
         DispatchQueue.main.async {
             let panel = NSSavePanel()
             panel.canCreateDirectories = true
@@ -16,6 +20,7 @@ enum SavePanelAdapter {
                 panel.allowsOtherFileTypes = false
             }
             panel.nameFieldStringValue = suggestedName.isEmpty ? "Virtual Machine.GhostVM" : "\(suggestedName).GhostVM"
+            panel.directoryURL = initialDirectoryURL
             panel.prompt = "Create"
             panel.title = "Create Virtual Machine"
 


### PR DESCRIPTION
## Summary
- default Create VM suggested name now uses detected OS version (for example: macOS 15.2) instead of restore IPSW filename
- Create dialog now opens in the VM root folder (~/VMs) by default
- fallback behavior remains: if version is unavailable, suggested name falls back to restore filename

## Validation
- xcodebuild -project macOS/GhostVM.xcodeproj -scheme GhostVM -destination 'platform=macOS' -configuration Debug build

Closes #102
