### PR TITLE
Check for updates in background on app launch

### DIFF
--- a/macOS/GhostVM/App2AppDelegate.swift
+++ b/macOS/GhostVM/App2AppDelegate.swift
@@ -83,6 +83,7 @@ final class App2AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         AppIconAdapter.shared.start()
+        updaterController.updater.checkForUpdatesInBackground()
     }
 
     func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {


### PR DESCRIPTION
## Summary
- Adds `updaterController.updater.checkForUpdatesInBackground()` to `applicationDidFinishLaunching`
- Only shows the Sparkle update window when an update is actually available — no "you're up to date" dialog on every launch

## Test plan
- [ ] `make app` builds successfully
- [ ] Launch the app — no update dialog appears (current version matches appcast)
- [ ] Manual "Check for Updates..." menu item still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)