### PR TITLE
Add app ID entitlements for provisioning profile matching

### DIFF
--- a/macOS/GhostVM/entitlements.plist
+++ b/macOS/GhostVM/entitlements.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.application-identifier</key>
+	<string>3FGZQE8AW3.org.ghostvm.ghostvm</string>
+	<key>com.apple.developer.team-identifier</key>
+	<string>3FGZQE8AW3</string>
 	<key>com.apple.security.virtualization</key>
 	<true/>
 	<key>com.apple.security.network.client</key>

--- a/macOS/GhostVMHelper/entitlements.plist
+++ b/macOS/GhostVMHelper/entitlements.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>com.apple.application-identifier</key>
+	<string>3FGZQE8AW3.org.ghostvm.ghostvm.helper</string>
+	<key>com.apple.developer.team-identifier</key>
+	<string>3FGZQE8AW3</string>
 	<key>com.apple.security.virtualization</key>
 	<true/>
 	<key>com.apple.security.network.client</key>


### PR DESCRIPTION
## Summary
- Add `com.apple.application-identifier` and `com.apple.developer.team-identifier` to both GhostVM and GhostVMHelper entitlements plists
- These are required for AMFI to match the embedded provisioning profile to the app at launch
- Without them, the `com.apple.vm.networking` restricted entitlement fails validation with "No matching profile found" and the app is SIGKILL'd

## Test plan
- [x] Built dist DMG with `make dist`
- [x] Notarized successfully
- [x] App launches from mounted DMG without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)