### PR TITLE
Fix OpenURL permission prompt anchor and port forward panel references

### DIFF
--- a/macOS/GhostVMHelper/HelperToolbar.swift
+++ b/macOS/GhostVMHelper/HelperToolbar.swift
@@ -1212,10 +1212,10 @@ final class HelperToolbar: NSObject, NSToolbarDelegate, NSMenuDelegate, PortForw
             self.delegate?.toolbarURLPermissionPanelDidClose(self)
         }
 
-        if let button = clipboardSyncItem?.view, button.window != nil {
+        if let button = captureCommandsItem?.view, button.window != nil {
             panel.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
-        } else if let button = captureKeysItem?.view, button.window != nil {
-            panel.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
+        } else if let window = self.window {
+            panel.showAsAlert(in: window)
         } else {
             return
         }
@@ -1270,20 +1270,20 @@ final class HelperToolbar: NSObject, NSToolbarDelegate, NSMenuDelegate, PortForw
     }
 
     func closePortForwardPermissionPopover() {
-        portForwardNotificationPanel?.close()
-        portForwardNotificationPanel = nil
+        portForwardPermissionPanel?.close()
+        portForwardPermissionPanel = nil
     }
 
     var isPortForwardPermissionPopoverShown: Bool {
-        portForwardNotificationPanel?.isShown ?? false
+        portForwardPermissionPanel?.isShown ?? false
     }
 
     func setPortForwardPermissionMappings(_ mappings: [(guestPort: UInt16, hostPort: UInt16, processName: String?)]) {
-        portForwardNotificationPanel?.setPortMappings(mappings)
+        portForwardPermissionPanel?.setPortMappings(mappings)
     }
 
     func addPortForwardPermissionMappings(_ mappings: [(guestPort: UInt16, hostPort: UInt16, processName: String?)]) {
-        portForwardNotificationPanel?.addPortMappings(mappings)
+        portForwardPermissionPanel?.addPortMappings(mappings)
     }
 
     func showPortForwardNotificationPopover() {


### PR DESCRIPTION
## Summary
- Point the OpenURL permission popover at the ellipsis menu (`captureCommandsItem`) instead of unrelated clipboard/keyboard toolbar buttons
- Add an `NSAlert` sheet fallback when the toolbar button view is unavailable, keeping the prompt within the app window rather than floating above other applications
- Fix copy-paste bug where four `portForwardPermission*` methods incorrectly referenced `portForwardNotificationPanel` instead of `portForwardPermissionPanel`

## Test plan
- [ ] Run a VM with GhostTools connected and trigger a URL open from the guest — popover should point at the (...) menu
- [ ] If the (...) menu toolbar item is hidden/removed, the prompt should appear as a sheet alert on the window
- [ ] Trigger a port forward permission prompt — confirm it displays and dismisses correctly
- [ ] Trigger a port forward notification — confirm it still works independently
- [ ] Confirm the URL prompt does not float above other macOS windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)