### PR TITLE
Fix port forward deadlock with blocking vsock I/O

### DIFF
--- a/macOS/GhostTools/Sources/GhostTools/Server/AsyncVSockIO.swift
+++ b/macOS/GhostTools/Sources/GhostTools/Server/AsyncVSockIO.swift
@@ -9,6 +9,182 @@ public enum AsyncVSockIOError: Error {
     case cancelled
 }
 
+// MARK: - SocketChannel protocol
+
+public protocol SocketChannel: Sendable {
+    func read(maxBytes: Int) async throws -> Data?
+    func writeAll(_ data: Data) async throws
+    func shutdownWrite() throws
+    func close()
+}
+
+extension SocketChannel {
+    public func readExactly(_ count: Int) async throws -> Data {
+        precondition(count >= 0, "readExactly(_:) requires non-negative count")
+        if count == 0 { return Data() }
+
+        var result = Data()
+        result.reserveCapacity(count)
+
+        while result.count < count {
+            let remaining = count - result.count
+            guard let chunk = try await read(maxBytes: remaining) else {
+                throw AsyncVSockIOError.eofBeforeExpected(expected: count, received: result.count)
+            }
+            result.append(chunk)
+        }
+
+        return result
+    }
+}
+
+// MARK: - BlockingVSockChannel
+
+/// Blocking I/O channel for vsock file descriptors.
+///
+/// Uses dedicated DispatchQueue threads for read and write, bridged to async/await
+/// via CheckedContinuation. This works around the macOS limitation where kqueue/poll/
+/// DispatchSource don't fire for AF_VSOCK sockets.
+public final class BlockingVSockChannel: SocketChannel, @unchecked Sendable {
+    private let readQueue = DispatchQueue(label: "org.ghostvm.blockingvsock.read", qos: .userInitiated)
+    private let writeQueue = DispatchQueue(label: "org.ghostvm.blockingvsock.write", qos: .userInitiated)
+    private let stateLock = NSLock()
+
+    private var fd: Int32
+    private let ownsFD: Bool
+    private var isClosed = false
+
+    public init(fd: Int32, ownsFD: Bool = false) {
+        self.fd = fd
+        self.ownsFD = ownsFD
+
+        // Ensure blocking mode (clear O_NONBLOCK)
+        let flags = fcntl(fd, F_GETFL, 0)
+        if flags >= 0 && (flags & O_NONBLOCK) != 0 {
+            _ = fcntl(fd, F_SETFL, flags & ~O_NONBLOCK)
+        }
+    }
+
+    deinit {
+        if ownsFD {
+            close()
+        }
+    }
+
+    public func read(maxBytes: Int) async throws -> Data? {
+        precondition(maxBytes > 0, "read(maxBytes:) requires maxBytes > 0")
+
+        let currentFD = try validatedFD()
+
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Data?, Error>) in
+                readQueue.async {
+                    var buffer = [UInt8](repeating: 0, count: maxBytes)
+                    while true {
+                        let n = Darwin.read(currentFD, &buffer, buffer.count)
+                        if n > 0 {
+                            continuation.resume(returning: Data(buffer[0..<n]))
+                            return
+                        }
+                        if n == 0 {
+                            continuation.resume(returning: nil)
+                            return
+                        }
+                        let err = errno
+                        if err == EINTR { continue }
+                        continuation.resume(throwing: AsyncVSockIOError.syscall(op: "read", errno: err))
+                        return
+                    }
+                }
+            }
+        } onCancel: {
+            self.shutdownForCancel()
+        }
+    }
+
+    public func writeAll(_ data: Data) async throws {
+        if data.isEmpty { return }
+
+        let currentFD = try validatedFD()
+
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                writeQueue.async {
+                    var offset = 0
+                    while offset < data.count {
+                        let written = data.withUnsafeBytes { ptr in
+                            Darwin.write(currentFD, ptr.baseAddress! + offset, data.count - offset)
+                        }
+                        if written > 0 {
+                            offset += written
+                            continue
+                        }
+                        if written == 0 {
+                            continuation.resume(throwing: AsyncVSockIOError.syscall(op: "write", errno: EPIPE))
+                            return
+                        }
+                        let err = errno
+                        if err == EINTR { continue }
+                        continuation.resume(throwing: AsyncVSockIOError.syscall(op: "write", errno: err))
+                        return
+                    }
+                    continuation.resume(returning: ())
+                }
+            }
+        } onCancel: {
+            self.shutdownForCancel()
+        }
+    }
+
+    public func shutdownWrite() throws {
+        let currentFD = try validatedFD()
+        if Darwin.shutdown(currentFD, SHUT_WR) < 0 {
+            let err = errno
+            if err != ENOTCONN {
+                throw AsyncVSockIOError.syscall(op: "shutdown", errno: err)
+            }
+        }
+    }
+
+    public func close() {
+        stateLock.lock()
+        if isClosed {
+            stateLock.unlock()
+            return
+        }
+        isClosed = true
+        let currentFD = fd
+        fd = -1
+        stateLock.unlock()
+
+        if currentFD >= 0 {
+            Darwin.close(currentFD)
+        }
+    }
+
+    private func validatedFD() throws -> Int32 {
+        stateLock.lock()
+        defer { stateLock.unlock() }
+        if isClosed || fd < 0 {
+            throw AsyncVSockIOError.closed
+        }
+        return fd
+    }
+
+    /// Unblock any threads blocked in read/write by shutting down the socket.
+    /// Safer than close() because it avoids fd-reuse races.
+    private func shutdownForCancel() {
+        stateLock.lock()
+        let currentFD = fd
+        stateLock.unlock()
+        if currentFD >= 0 {
+            Darwin.shutdown(currentFD, SHUT_RDWR)
+        }
+    }
+}
+
+// MARK: - AsyncVSockIO (non-blocking, DispatchSource-based — for TCP)
+
 private final class AsyncIOWaiter: @unchecked Sendable {
     private let lock = NSLock()
     private var continuation: CheckedContinuation<Void, Error>?
@@ -76,19 +252,17 @@ private final class WaiterHolder: @unchecked Sendable {
     }
 }
 
-public final class AsyncVSockIO {
+public final class AsyncVSockIO: SocketChannel, @unchecked Sendable {
     private let ioQueue = DispatchQueue(label: "org.ghostvm.asyncvsockio", qos: .userInitiated)
     private let stateLock = NSLock()
 
     private var fd: Int32
     private let ownsFD: Bool
-    private let pollOnEAGAIN: Bool
     private var isClosed = false
 
-    public init(fd: Int32, ownsFD: Bool = false, pollOnEAGAIN: Bool = false) {
+    public init(fd: Int32, ownsFD: Bool = false) {
         self.fd = fd
         self.ownsFD = ownsFD
-        self.pollOnEAGAIN = pollOnEAGAIN
 
         let flags = fcntl(fd, F_GETFL, 0)
         if flags < 0 {
@@ -222,28 +396,15 @@ public final class AsyncVSockIO {
     }
 
     private func waitForReadability() async throws {
-        if pollOnEAGAIN {
-            try await pollSleep()
-            return
-        }
         try await waitForEvent(makeSource: { fd in
             DispatchSource.makeReadSource(fileDescriptor: fd, queue: ioQueue)
         })
     }
 
     private func waitForWritability() async throws {
-        if pollOnEAGAIN {
-            try await pollSleep()
-            return
-        }
         try await waitForEvent(makeSource: { fd in
             DispatchSource.makeWriteSource(fileDescriptor: fd, queue: ioQueue)
         })
-    }
-
-    private func pollSleep() async throws {
-        if Task.isCancelled { throw AsyncVSockIOError.cancelled }
-        try await Task.sleep(nanoseconds: 1_000_000) // 1ms
     }
 
     private func waitForEvent(makeSource: (Int32) -> DispatchSourceProtocol) async throws {
@@ -270,7 +431,9 @@ public final class AsyncVSockIO {
     }
 }
 
-public func pipeBidirectional(_ a: AsyncVSockIO, _ b: AsyncVSockIO) async throws {
+// MARK: - Relay functions
+
+public func pipeBidirectional(_ a: some SocketChannel, _ b: some SocketChannel) async throws {
     try await withThrowingTaskGroup(of: Void.self) { group in
         group.addTask {
             try await pipeOneWay(from: a, to: b)
@@ -287,7 +450,7 @@ public func pipeBidirectional(_ a: AsyncVSockIO, _ b: AsyncVSockIO) async throws
     }
 }
 
-private func pipeOneWay(from source: AsyncVSockIO, to destination: AsyncVSockIO) async throws {
+private func pipeOneWay(from source: some SocketChannel, to destination: some SocketChannel) async throws {
     while let chunk = try await source.read(maxBytes: 65536) {
         if !chunk.isEmpty {
             try await destination.writeAll(chunk)

--- a/macOS/GhostTools/Sources/GhostTools/Server/TunnelServer.swift
+++ b/macOS/GhostTools/Sources/GhostTools/Server/TunnelServer.swift
@@ -152,7 +152,7 @@ final class TunnelServer: @unchecked Sendable {
         let connectionID = UUID().uuidString
         Self.logger.debug("New incoming host connection id=\(connectionID, privacy: .public) fd=\(vsockFd)")
 
-        let vsockIO = AsyncVSockIO(fd: vsockFd, ownsFD: true, pollOnEAGAIN: true)
+        let vsockIO = BlockingVSockChannel(fd: vsockFd, ownsFD: true)
         defer {
             vsockIO.close()
             Self.logger.debug("Connection closed id=\(connectionID, privacy: .public) fd=\(vsockFd)")
@@ -367,7 +367,7 @@ final class TunnelServer: @unchecked Sendable {
     }
 
     /// Send an error response
-    private func sendError(_ io: AsyncVSockIO, message: String) async {
+    private func sendError(_ io: some SocketChannel, message: String) async {
         let response = "ERROR \(message)\r\n"
         do {
             try await io.writeAll(Data(response.utf8))
@@ -383,7 +383,7 @@ final class TunnelServer: @unchecked Sendable {
         case transport(AsyncVSockIOError)
     }
 
-    private func readHandshakeCommand(_ io: AsyncVSockIO) async throws -> Data {
+    private func readHandshakeCommand(_ io: some SocketChannel) async throws -> Data {
         try await withThrowingTaskGroup(of: Data.self) { group in
             group.addTask {
                 do {

--- a/macOS/GhostTools/Tests/GhostToolsTests/AsyncVSockIOTests.swift
+++ b/macOS/GhostTools/Tests/GhostToolsTests/AsyncVSockIOTests.swift
@@ -12,6 +12,8 @@ final class AsyncVSockIOTests: XCTestCase {
         return (fds[0], fds[1])
     }
 
+    // MARK: - AsyncVSockIO tests
+
     func testWriteAllAndRead() async throws {
         let (fdA, fdB) = try makeSocketPair()
         let ioA = AsyncVSockIO(fd: fdA, ownsFD: true)
@@ -97,78 +99,6 @@ final class AsyncVSockIOTests: XCTestCase {
         ioB.close()
     }
 
-    // MARK: - pollOnEAGAIN tests
-
-    func testPollOnEAGAINWriteAndRead() async throws {
-        let (fdA, fdB) = try makeSocketPair()
-        let ioA = AsyncVSockIO(fd: fdA, ownsFD: true, pollOnEAGAIN: true)
-        let ioB = AsyncVSockIO(fd: fdB, ownsFD: true, pollOnEAGAIN: true)
-
-        try await ioA.writeAll(Data("hello-poll".utf8))
-        let data = try await ioB.read(maxBytes: 32)
-        XCTAssertEqual(String(data: data ?? Data(), encoding: .utf8), "hello-poll")
-
-        ioA.close()
-        ioB.close()
-    }
-
-    func testPollOnEAGAINLargeTransfer() async throws {
-        let (fdA, fdB) = try makeSocketPair()
-        let ioA = AsyncVSockIO(fd: fdA, ownsFD: true, pollOnEAGAIN: true)
-        let ioB = AsyncVSockIO(fd: fdB, ownsFD: true, pollOnEAGAIN: true)
-
-        // 256KB — large enough to trigger EAGAIN on Unix sockets
-        let size = 256 * 1024
-        let payload = Data((0..<size).map { UInt8($0 & 0xFF) })
-
-        let writeTask = Task {
-            try await ioA.writeAll(payload)
-            try ioA.shutdownWrite()
-        }
-
-        var received = Data()
-        received.reserveCapacity(size)
-        while let chunk = try await ioB.read(maxBytes: 65536) {
-            received.append(chunk)
-        }
-
-        try await writeTask.value
-        XCTAssertEqual(received.count, size)
-        XCTAssertEqual(received, payload)
-
-        ioA.close()
-        ioB.close()
-    }
-
-    func testPollOnEAGAINBidirectional() async throws {
-        let (fdL1, fdL2) = try makeSocketPair()
-        let (fdR1, fdR2) = try makeSocketPair()
-
-        let bridgeLeft = AsyncVSockIO(fd: fdL2, ownsFD: true, pollOnEAGAIN: true)
-        let bridgeRight = AsyncVSockIO(fd: fdR2, ownsFD: true, pollOnEAGAIN: true)
-        let clientLeft = AsyncVSockIO(fd: fdL1, ownsFD: true)
-        let clientRight = AsyncVSockIO(fd: fdR1, ownsFD: true)
-
-        let bridgeTask = Task {
-            try await pipeBidirectional(bridgeLeft, bridgeRight)
-        }
-
-        try await clientLeft.writeAll(Data("left->right".utf8))
-        let fromLeft = try await clientRight.readExactly("left->right".utf8.count)
-        XCTAssertEqual(String(data: fromLeft, encoding: .utf8), "left->right")
-
-        try await clientRight.writeAll(Data("right->left".utf8))
-        let fromRight = try await clientLeft.readExactly("right->left".utf8.count)
-        XCTAssertEqual(String(data: fromRight, encoding: .utf8), "right->left")
-
-        clientLeft.close()
-        clientRight.close()
-
-        _ = try? await bridgeTask.value
-        bridgeLeft.close()
-        bridgeRight.close()
-    }
-
     func testPipeBidirectionalCopiesBothDirections() async throws {
         let (fdL1, fdL2) = try makeSocketPair()
         let (fdR1, fdR2) = try makeSocketPair()
@@ -196,5 +126,134 @@ final class AsyncVSockIOTests: XCTestCase {
         _ = try? await bridgeTask.value
         bridgeLeft.close()
         bridgeRight.close()
+    }
+
+    // MARK: - BlockingVSockChannel tests
+
+    func testBlockingChannelWriteAndRead() async throws {
+        let (fdA, fdB) = try makeSocketPair()
+        let chA = BlockingVSockChannel(fd: fdA, ownsFD: true)
+        let chB = BlockingVSockChannel(fd: fdB, ownsFD: true)
+
+        try await chA.writeAll(Data("hello-blocking".utf8))
+        let data = try await chB.read(maxBytes: 32)
+        XCTAssertEqual(String(data: data ?? Data(), encoding: .utf8), "hello-blocking")
+
+        chA.close()
+        chB.close()
+    }
+
+    func testBlockingChannelLargeTransfer() async throws {
+        let (fdA, fdB) = try makeSocketPair()
+        let chA = BlockingVSockChannel(fd: fdA, ownsFD: true)
+        let chB = BlockingVSockChannel(fd: fdB, ownsFD: true)
+
+        // 1MB — large enough to trigger backpressure
+        let size = 1024 * 1024
+        let payload = Data((0..<size).map { UInt8($0 & 0xFF) })
+
+        let writeTask = Task {
+            try await chA.writeAll(payload)
+            try chA.shutdownWrite()
+        }
+
+        var received = Data()
+        received.reserveCapacity(size)
+        while let chunk = try await chB.read(maxBytes: 65536) {
+            received.append(chunk)
+        }
+
+        try await writeTask.value
+        XCTAssertEqual(received.count, size)
+        XCTAssertEqual(received, payload)
+
+        chA.close()
+        chB.close()
+    }
+
+    func testBlockingChannelCancellation() async throws {
+        let (fdA, fdB) = try makeSocketPair()
+        let chA = BlockingVSockChannel(fd: fdA, ownsFD: true)
+        let chB = BlockingVSockChannel(fd: fdB, ownsFD: true)
+
+        let task = Task {
+            try await chB.read(maxBytes: 16)
+        }
+
+        try await Task.sleep(nanoseconds: 50_000_000)
+        task.cancel()
+
+        // shutdown(SHUT_RDWR) unblocks the read — on Unix sockets this returns
+        // nil (EOF) rather than an error. Either outcome means cancellation worked.
+        do {
+            let result = try await task.value
+            // nil means the read saw EOF from shutdown — that's correct
+            XCTAssertNil(result, "Expected nil (EOF) or error after cancellation")
+        } catch {
+            // An error is also acceptable
+        }
+
+        chA.close()
+        chB.close()
+    }
+
+    func testBlockingChannelBidirectionalPipe() async throws {
+        let (fdL1, fdL2) = try makeSocketPair()
+        let (fdR1, fdR2) = try makeSocketPair()
+
+        let bridgeLeft = BlockingVSockChannel(fd: fdL2, ownsFD: true)
+        let bridgeRight = BlockingVSockChannel(fd: fdR2, ownsFD: true)
+        let clientLeft = AsyncVSockIO(fd: fdL1, ownsFD: true)
+        let clientRight = AsyncVSockIO(fd: fdR1, ownsFD: true)
+
+        let bridgeTask = Task {
+            try await pipeBidirectional(bridgeLeft, bridgeRight)
+        }
+
+        try await clientLeft.writeAll(Data("left->right".utf8))
+        let fromLeft = try await clientRight.readExactly("left->right".utf8.count)
+        XCTAssertEqual(String(data: fromLeft, encoding: .utf8), "left->right")
+
+        try await clientRight.writeAll(Data("right->left".utf8))
+        let fromRight = try await clientLeft.readExactly("right->left".utf8.count)
+        XCTAssertEqual(String(data: fromRight, encoding: .utf8), "right->left")
+
+        clientLeft.close()
+        clientRight.close()
+
+        _ = try? await bridgeTask.value
+        bridgeLeft.close()
+        bridgeRight.close()
+    }
+
+    // MARK: - Mixed channel pipe (simulates real port-forward: TCP AsyncVSockIO <-> vsock BlockingVSockChannel)
+
+    func testMixedChannelBidirectionalPipe() async throws {
+        let (fdL1, fdL2) = try makeSocketPair()
+        let (fdR1, fdR2) = try makeSocketPair()
+
+        let tcpSide = AsyncVSockIO(fd: fdL2, ownsFD: true)
+        let vsockSide = BlockingVSockChannel(fd: fdR2, ownsFD: true)
+        let clientLeft = AsyncVSockIO(fd: fdL1, ownsFD: true)
+        let clientRight = AsyncVSockIO(fd: fdR1, ownsFD: true)
+
+        let bridgeTask = Task {
+            try await pipeBidirectional(tcpSide, vsockSide)
+        }
+
+        try await clientLeft.writeAll(Data("tcp->vsock".utf8))
+        let fromTCP = try await clientRight.readExactly("tcp->vsock".utf8.count)
+        XCTAssertEqual(String(data: fromTCP, encoding: .utf8), "tcp->vsock")
+
+        try await clientRight.writeAll(Data("vsock->tcp".utf8))
+        let fromVsock = try await clientLeft.readExactly("vsock->tcp".utf8.count)
+        XCTAssertEqual(String(data: fromVsock, encoding: .utf8), "vsock->tcp")
+
+        clientLeft.close()
+        clientRight.close()
+
+        _ = try? await bridgeTask.value
+        tcpSide.close()
+        vsockSide.close()
     }
 }


### PR DESCRIPTION
## Summary

- Port forwarding stalls after ~256KB because neither DispatchSource (kqueue) nor 1ms polling work for AF_VSOCK on macOS
- Adds `BlockingVSockChannel` — blocking read/write on dedicated DispatchQueue threads, bridged to async/await via CheckedContinuation, with `shutdown(SHUT_RDWR)` for cancellation
- Introduces `SocketChannel` protocol to unify `AsyncVSockIO` (TCP, DispatchSource) and `BlockingVSockChannel` (vsock, blocking threads)
- Removes broken `pollOnEAGAIN` codepath

Vsock fds use `BlockingVSockChannel`; TCP fds continue using `AsyncVSockIO`. Tests pass including 1MB transfer and mixed-channel bidirectional pipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)