### PR TITLE
Add ellipsis to Terminate menu items per macOS HIG

### DIFF
--- a/macOS/GhostVMHelper/HelperToolbar.swift
+++ b/macOS/GhostVMHelper/HelperToolbar.swift
@@ -883,7 +883,7 @@ final class HelperToolbar: NSObject, NSToolbarDelegate, NSMenuDelegate, PortForw
         shutItem.isEnabled = vmRunning && shutDownEnabled
         captureCommandsMenu.addItem(shutItem)
 
-        let termItem = NSMenuItem(title: "Terminate", action: #selector(terminateVM), keyEquivalent: "")
+        let termItem = NSMenuItem(title: "Terminate…", action: #selector(terminateVM), keyEquivalent: "")
         termItem.target = self
         termItem.isEnabled = vmRunning
         captureCommandsMenu.addItem(termItem)

--- a/macOS/GhostVMHelper/main.swift
+++ b/macOS/GhostVMHelper/main.swift
@@ -476,7 +476,7 @@ final class HelperAppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate
         shutdownItem.target = self
         vmMenu.addItem(shutdownItem)
 
-        let terminateItem = NSMenuItem(title: "Terminate", action: nil, keyEquivalent: "")
+        let terminateItem = NSMenuItem(title: "Terminate…", action: nil, keyEquivalent: "")
         terminateItem.action = #selector(terminateVMAction)
         terminateItem.target = self
         vmMenu.addItem(terminateItem)


### PR DESCRIPTION
## Summary
- Rename **Terminate** → **Terminate…** in the VM menu bar and toolbar capture-commands dropdown, since the action shows a confirmation alert before executing (macOS HIG convention).
- Suspend and Shut Down act immediately without a dialog, so they remain unchanged.

Closes #192

🤖 Generated with [Claude Code](https://claude.com/claude-code)