### PR TITLE
Fix --headless flag being silently ignored

### DIFF
--- a/macOS/GhostVMKit/Operations/VMController.swift
+++ b/macOS/GhostVMKit/Operations/VMController.swift
@@ -1044,7 +1044,7 @@ public final class VMController {
 
     /// Start a VM from the CLI. Blocks until the VM terminates.
     public func startVM(bundleURL: URL, headless: Bool, runtimeSharedFolder: RuntimeSharedFolderOverride?) throws {
-        let session = try makeWindowlessSession(bundleURL: bundleURL, runtimeSharedFolder: runtimeSharedFolder)
+        let session = try makeWindowlessSession(bundleURL: bundleURL, headless: headless, runtimeSharedFolder: runtimeSharedFolder)
         let vmName = displayName(for: bundleURL)
 
         if session.wasSuspended {
@@ -1094,7 +1094,7 @@ public final class VMController {
 
     /// Resume a suspended VM from the CLI. Blocks until the VM terminates.
     public func resumeVM(bundleURL: URL, headless: Bool, runtimeSharedFolder: RuntimeSharedFolderOverride?) throws {
-        let session = try makeWindowlessSession(bundleURL: bundleURL, runtimeSharedFolder: runtimeSharedFolder)
+        let session = try makeWindowlessSession(bundleURL: bundleURL, headless: headless, runtimeSharedFolder: runtimeSharedFolder)
         let vmName = displayName(for: bundleURL)
 
         guard session.wasSuspended else {
@@ -1215,7 +1215,7 @@ public final class VMController {
 
     // MARK: - Windowless Session Support (for SwiftUI apps that manage their own window)
 
-    public func makeWindowlessSession(bundleURL: URL, runtimeSharedFolder: RuntimeSharedFolderOverride?) throws -> WindowlessVMSession {
+    public func makeWindowlessSession(bundleURL: URL, headless: Bool = false, runtimeSharedFolder: RuntimeSharedFolderOverride?) throws -> WindowlessVMSession {
         let layout = try layoutForExistingBundle(at: bundleURL)
         let store = VMConfigStore(layout: layout)
         var config = try store.load()
@@ -1240,7 +1240,7 @@ public final class VMController {
             }
         }
 
-        return try WindowlessVMSession(name: name, bundleURL: bundleURL, layout: layout, storedConfig: config, runtimeSharedFolder: runtimeSharedFolder)
+        return try WindowlessVMSession(name: name, bundleURL: bundleURL, layout: layout, storedConfig: config, headless: headless, runtimeSharedFolder: runtimeSharedFolder)
     }
 
     // MARK: - Private Helpers

--- a/macOS/GhostVMKit/Session/WindowlessVMSession.swift
+++ b/macOS/GhostVMKit/Session/WindowlessVMSession.swift
@@ -45,13 +45,13 @@ public final class WindowlessVMSession: NSObject, VZVirtualMachineDelegate {
     /// Whether the VM was suspended and should be resumed instead of started fresh.
     public let wasSuspended: Bool
 
-    public init(name: String, bundleURL: URL, layout: VMFileLayout, storedConfig: VMStoredConfig, runtimeSharedFolder: RuntimeSharedFolderOverride?) throws {
+    public init(name: String, bundleURL: URL, layout: VMFileLayout, storedConfig: VMStoredConfig, headless: Bool = false, runtimeSharedFolder: RuntimeSharedFolderOverride?) throws {
         self.wasSuspended = storedConfig.isSuspended && FileManager.default.fileExists(atPath: layout.suspendStateURL.path)
         self.name = name
         self.bundlePath = bundleURL.path
         self.layout = layout
         let builder = VMConfigurationBuilder(layout: layout, storedConfig: storedConfig)
-        let configuration = try builder.makeConfiguration(headless: false, connectSerialToStandardIO: false, runtimeSharedFolder: runtimeSharedFolder)
+        let configuration = try builder.makeConfiguration(headless: headless, connectSerialToStandardIO: false, runtimeSharedFolder: runtimeSharedFolder)
         self.vmQueue = DispatchQueue(label: "vmctl.windowless.\(name)")
         self._virtualMachine = VZVirtualMachine(configuration: configuration, queue: vmQueue)
         super.init()


### PR DESCRIPTION
## Summary

- Thread the `headless` parameter from `startVM`/`resumeVM` through `makeWindowlessSession` to `WindowlessVMSession.init`, which previously hardcoded `headless: false`
- VMs started with `vmctl start --headless` will now correctly omit graphics display, keyboard, and pointing devices

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)