### PR TITLE
Fix --headless flag and add vmctl entitlements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ CODESIGN_ID ?= Apple Development
 GHOSTTOOLS_SIGN_ID ?= $(CODESIGN_ID)
 APP_PROVISIONING_PROFILE ?= .var/profiles/GhostVM_App_Distribution.provisionprofile
 HELPER_PROVISIONING_PROFILE ?= .var/profiles/GhostVM_Helper_Distribution.provisionprofile
+VMCTL_PROVISIONING_PROFILE ?= .var/profiles/vmctl_command_line.provisionprofile
 
 # Inject build timestamp into patch version during development builds.
 # Set to 0 for production releases (make dist does this automatically).
@@ -97,7 +98,7 @@ cli: $(XCODE_PROJECT)
 		-derivedDataPath $(BUILD_DIR) \
 		DEVELOPMENT_TEAM="$(DEVELOPMENT_TEAM)" \
 		build
-	@echo "vmctl built at: $(BUILD_DIR)/Build/Products/$(XCODE_CONFIG)/vmctl"
+	@echo "vmctl built at: $(BUILD_DIR)/Build/Products/$(XCODE_CONFIG)/vmctl.app/Contents/MacOS/vmctl"
 
 # Build the SwiftUI app via xcodebuild (includes GhostTools.dmg)
 app: $(XCODE_PROJECT) dmg ghostvm-icon
@@ -400,15 +401,15 @@ dist:
 	fi
 	@# Verify provisioning profile certificates match the signing identity (AMFI rejects
 	@# apps where the profile cert doesn't match the signing cert, even if entitlements match)
-	@scripts/verify-profile-cert.sh "$(DIST_CODESIGN_ID)" $(APP_PROVISIONING_PROFILE) $(HELPER_PROVISIONING_PROFILE)
+	@scripts/verify-profile-cert.sh "$(DIST_CODESIGN_ID)" $(APP_PROVISIONING_PROFILE) $(HELPER_PROVISIONING_PROFILE) $(VMCTL_PROVISIONING_PROFILE)
 	@echo "Creating distribution DMG (version $(VERSION))..."
 	@echo "Signing with: $(DIST_CODESIGN_ID)"
 	@rm -rf "$(DIST_DIR)"
 	@mkdir -p "$(DIST_DIR)/dmg-stage"
 	@# Stage app bundle
 	cp -R "$(BUILD_DIR)/Build/Products/$(XCODE_CONFIG)/$(APP_NAME).app" "$(DIST_DIR)/dmg-stage/"
-	@# Embed vmctl CLI inside the app bundle
-	cp "$(BUILD_DIR)/Build/Products/$(XCODE_CONFIG)/vmctl" "$(DIST_DIR)/dmg-stage/$(APP_NAME).app/Contents/MacOS/"
+	@# Embed vmctl.app inside the app bundle (alongside GhostVMHelper)
+	cp -R "$(BUILD_DIR)/Build/Products/$(XCODE_CONFIG)/vmctl.app" "$(DIST_DIR)/dmg-stage/$(APP_NAME).app/Contents/PlugIns/Helpers/"
 	@# Restricted entitlements (e.g. com.apple.vm.networking) require a matching embedded provisioning profile.
 	@if /usr/libexec/PlistBuddy -c "Print :com.apple.vm.networking" macOS/GhostVMHelper/entitlements.plist >/dev/null 2>&1 && [ -z "$(HELPER_PROVISIONING_PROFILE)" ]; then \
 		echo "ERROR: HELPER_PROVISIONING_PROFILE is required for macOS/GhostVMHelper/entitlements.plist (com.apple.vm.networking present)"; \
@@ -425,6 +426,14 @@ dist:
 	@if [ -n "$(APP_PROVISIONING_PROFILE)" ]; then \
 		test -f "$(APP_PROVISIONING_PROFILE)" || (echo "ERROR: APP_PROVISIONING_PROFILE not found: $(APP_PROVISIONING_PROFILE)" && exit 1); \
 		cp "$(APP_PROVISIONING_PROFILE)" "$(DIST_DIR)/dmg-stage/$(APP_NAME).app/Contents/embedded.provisionprofile"; \
+	fi
+	@if /usr/libexec/PlistBuddy -c "Print :com.apple.vm.networking" macOS/GhostVM/vmctl/entitlements.plist >/dev/null 2>&1 && [ -z "$(VMCTL_PROVISIONING_PROFILE)" ]; then \
+		echo "ERROR: VMCTL_PROVISIONING_PROFILE is required for macOS/GhostVM/vmctl/entitlements.plist (com.apple.vm.networking present)"; \
+		exit 1; \
+	fi
+	@if [ -n "$(VMCTL_PROVISIONING_PROFILE)" ]; then \
+		test -f "$(VMCTL_PROVISIONING_PROFILE)" || (echo "ERROR: VMCTL_PROVISIONING_PROFILE not found: $(VMCTL_PROVISIONING_PROFILE)" && exit 1); \
+		cp "$(VMCTL_PROVISIONING_PROFILE)" "$(DIST_DIR)/dmg-stage/$(APP_NAME).app/Contents/PlugIns/Helpers/vmctl.app/Contents/embedded.provisionprofile"; \
 	fi
 	@# --- Inside-out code signing for notarization ---
 	@echo "Signing nested components (inside-out)..."
@@ -479,11 +488,24 @@ dist:
 			codesign --force --options runtime --timestamp -s "$(DIST_CODESIGN_ID)" "$$dylib"; \
 		fi; \
 	done
-	@# 5. Sign vmctl binary
-	@echo "  Signing vmctl"
+	@# 5. Sign vmctl.app (frameworks, then the bundle itself with entitlements)
+	@for fw in "$(DIST_DIR)/dmg-stage/$(APP_NAME).app/Contents/PlugIns/Helpers/vmctl.app/Contents/Frameworks/"*.framework; do \
+		if [ -d "$$fw" ]; then \
+			echo "  Signing $$(basename $$fw) (in vmctl)"; \
+			codesign --force --options runtime --timestamp -s "$(DIST_CODESIGN_ID)" "$$fw"; \
+		fi; \
+	done
+	@for dylib in "$(DIST_DIR)/dmg-stage/$(APP_NAME).app/Contents/PlugIns/Helpers/vmctl.app/Contents/Frameworks/"*.dylib; do \
+		if [ -f "$$dylib" ]; then \
+			echo "  Signing $$(basename $$dylib) (in vmctl)"; \
+			codesign --force --options runtime --timestamp -s "$(DIST_CODESIGN_ID)" "$$dylib"; \
+		fi; \
+	done
+	@echo "  Signing vmctl.app"
 	codesign --force --options runtime --timestamp \
+		--entitlements macOS/GhostVM/vmctl/entitlements.plist \
 		-s "$(DIST_CODESIGN_ID)" \
-		"$(DIST_DIR)/dmg-stage/$(APP_NAME).app/Contents/MacOS/vmctl"
+		"$(DIST_DIR)/dmg-stage/$(APP_NAME).app/Contents/PlugIns/Helpers/vmctl.app"
 	@# 5b. Re-create GhostTools.dmg with Developer ID signing for notarization
 	@echo "  Re-signing GhostTools for distribution..."
 	@rm -rf "$(DIST_DIR)/ghosttools-stage"
@@ -524,7 +546,7 @@ dist:
 		--wait
 	xcrun stapler staple "$(DIST_DIR)/$(DMG_NAME)-$(VERSION).dmg"
 	@echo "Distribution created: $(DIST_DIR)/$(DMG_NAME)-$(VERSION).dmg"
-	@echo "vmctl is at: $(APP_NAME).app/Contents/MacOS/vmctl"
+	@echo "vmctl is at: $(APP_NAME).app/Contents/PlugIns/Helpers/vmctl.app/Contents/MacOS/vmctl"
 
 # Sign DMG for Sparkle auto-updates (run after make dist)
 sparkle-sign: sparkle-tools

--- a/macOS/GhostVM/vmctl/CLI.swift
+++ b/macOS/GhostVM/vmctl/CLI.swift
@@ -371,14 +371,14 @@ struct CLI {
     private func findHelperApp() -> URL? {
         let vmctlURL = URL(fileURLWithPath: CommandLine.arguments[0]).resolvingSymlinksInPath()
 
-        // When embedded in GhostVM.app/Contents/MacOS/vmctl:
-        // Helper is at GhostVM.app/Contents/PlugIns/Helpers/GhostVMHelper.app
-        let appContents = vmctlURL
-            .deletingLastPathComponent()  // MacOS/
-            .deletingLastPathComponent()  // Contents/
-        let embeddedHelper = appContents
-            .appendingPathComponent("PlugIns")
-            .appendingPathComponent("Helpers")
+        // When embedded in GhostVM.app/Contents/PlugIns/Helpers/vmctl.app/Contents/MacOS/vmctl:
+        // Helper is a sibling at GhostVM.app/Contents/PlugIns/Helpers/GhostVMHelper.app
+        let helpersDir = vmctlURL
+            .deletingLastPathComponent()  // -> MacOS/
+            .deletingLastPathComponent()  // -> Contents/
+            .deletingLastPathComponent()  // -> vmctl.app/
+            .deletingLastPathComponent()  // -> Helpers/
+        let embeddedHelper = helpersDir
             .appendingPathComponent("GhostVMHelper.app")
         if FileManager.default.fileExists(atPath: embeddedHelper.path) {
             return embeddedHelper

--- a/macOS/GhostVM/vmctl/entitlements.plist
+++ b/macOS/GhostVM/vmctl/entitlements.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.application-identifier</key>
+	<string>3FGZQE8AW3.org.ghostvm.vmctl</string>
+	<key>com.apple.developer.team-identifier</key>
+	<string>3FGZQE8AW3</string>
+	<key>com.apple.security.virtualization</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.vm.networking</key>
+	<true/>
+</dict>
+</plist>

--- a/macOS/GhostVMKit/Operations/VMController.swift
+++ b/macOS/GhostVMKit/Operations/VMController.swift
@@ -1044,7 +1044,7 @@ public final class VMController {
 
     /// Start a VM from the CLI. Blocks until the VM terminates.
     public func startVM(bundleURL: URL, headless: Bool, runtimeSharedFolder: RuntimeSharedFolderOverride?) throws {
-        let session = try makeWindowlessSession(bundleURL: bundleURL, runtimeSharedFolder: runtimeSharedFolder)
+        let session = try makeWindowlessSession(bundleURL: bundleURL, headless: headless, runtimeSharedFolder: runtimeSharedFolder)
         let vmName = displayName(for: bundleURL)
 
         if session.wasSuspended {
@@ -1094,7 +1094,7 @@ public final class VMController {
 
     /// Resume a suspended VM from the CLI. Blocks until the VM terminates.
     public func resumeVM(bundleURL: URL, headless: Bool, runtimeSharedFolder: RuntimeSharedFolderOverride?) throws {
-        let session = try makeWindowlessSession(bundleURL: bundleURL, runtimeSharedFolder: runtimeSharedFolder)
+        let session = try makeWindowlessSession(bundleURL: bundleURL, headless: headless, runtimeSharedFolder: runtimeSharedFolder)
         let vmName = displayName(for: bundleURL)
 
         guard session.wasSuspended else {
@@ -1215,7 +1215,7 @@ public final class VMController {
 
     // MARK: - Windowless Session Support (for SwiftUI apps that manage their own window)
 
-    public func makeWindowlessSession(bundleURL: URL, runtimeSharedFolder: RuntimeSharedFolderOverride?) throws -> WindowlessVMSession {
+    public func makeWindowlessSession(bundleURL: URL, headless: Bool = false, runtimeSharedFolder: RuntimeSharedFolderOverride?) throws -> WindowlessVMSession {
         let layout = try layoutForExistingBundle(at: bundleURL)
         let store = VMConfigStore(layout: layout)
         var config = try store.load()
@@ -1240,7 +1240,7 @@ public final class VMController {
             }
         }
 
-        return try WindowlessVMSession(name: name, bundleURL: bundleURL, layout: layout, storedConfig: config, runtimeSharedFolder: runtimeSharedFolder)
+        return try WindowlessVMSession(name: name, bundleURL: bundleURL, layout: layout, storedConfig: config, headless: headless, runtimeSharedFolder: runtimeSharedFolder)
     }
 
     // MARK: - Private Helpers

--- a/macOS/GhostVMKit/Session/WindowlessVMSession.swift
+++ b/macOS/GhostVMKit/Session/WindowlessVMSession.swift
@@ -45,13 +45,13 @@ public final class WindowlessVMSession: NSObject, VZVirtualMachineDelegate {
     /// Whether the VM was suspended and should be resumed instead of started fresh.
     public let wasSuspended: Bool
 
-    public init(name: String, bundleURL: URL, layout: VMFileLayout, storedConfig: VMStoredConfig, runtimeSharedFolder: RuntimeSharedFolderOverride?) throws {
+    public init(name: String, bundleURL: URL, layout: VMFileLayout, storedConfig: VMStoredConfig, headless: Bool = false, runtimeSharedFolder: RuntimeSharedFolderOverride?) throws {
         self.wasSuspended = storedConfig.isSuspended && FileManager.default.fileExists(atPath: layout.suspendStateURL.path)
         self.name = name
         self.bundlePath = bundleURL.path
         self.layout = layout
         let builder = VMConfigurationBuilder(layout: layout, storedConfig: storedConfig)
-        let configuration = try builder.makeConfiguration(headless: false, connectSerialToStandardIO: false, runtimeSharedFolder: runtimeSharedFolder)
+        let configuration = try builder.makeConfiguration(headless: headless, connectSerialToStandardIO: false, runtimeSharedFolder: runtimeSharedFolder)
         self.vmQueue = DispatchQueue(label: "vmctl.windowless.\(name)")
         self._virtualMachine = VZVirtualMachine(configuration: configuration, queue: vmQueue)
         super.init()

--- a/macOS/project.yml
+++ b/macOS/project.yml
@@ -48,7 +48,7 @@ targets:
         ENABLE_HARDENED_RUNTIME: YES
 
   vmctl:
-    type: tool
+    type: application
     platform: macOS
     sources:
       - path: GhostVM/vmctl
@@ -57,13 +57,17 @@ targets:
     dependencies:
       - target: GhostVMKit
         link: true
-        embed: false
+        embed: true
     settings:
       base:
         PRODUCT_NAME: vmctl
+        PRODUCT_BUNDLE_IDENTIFIER: org.ghostvm.vmctl
+        GENERATE_INFOPLIST_FILE: YES
+        INFOPLIST_KEY_LSBackgroundOnly: YES
         SWIFT_VERSION: "5.0"
         CODE_SIGN_STYLE: Automatic
         CODE_SIGN_IDENTITY: "Apple Development"
+        CODE_SIGN_ENTITLEMENTS: GhostVM/vmctl/entitlements.plist
         DEVELOPMENT_TEAM: ${DEVELOPMENT_TEAM}
         ENABLE_HARDENED_RUNTIME: YES
         SWIFT_INCLUDE_PATHS: "$(SRCROOT)/GhostVM/vmctl/CEditLine"
@@ -124,7 +128,8 @@ targets:
         embed: true
         codeSign: true
         copy:
-          destination: executables
+          destination: plugins
+          subpath: Helpers
       - target: GhostVMHelper
         embed: true
         codeSign: true


### PR DESCRIPTION
## Summary

- Thread `headless` parameter through `makeWindowlessSession` → `WindowlessVMSession` → `makeConfiguration()`, which previously hardcoded `headless: false` (#202)
- Convert vmctl from `type: tool` to `type: application` so Xcode auto-provisions it with restricted entitlements needed for headless VM execution (#204)
- Update `make dist` to handle vmctl.app with inside-out signing, entitlements, and provisioning profile embedding
- Fix `findHelperApp()` path traversal for vmctl's new location in `PlugIns/Helpers/vmctl.app`

Closes #202
Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)