### PR TITLE
Fix website build: move fs out of client module

### DIFF
--- a/Website/src/app/layout.tsx
+++ b/Website/src/app/layout.tsx
@@ -2,7 +2,8 @@ import type { Metadata } from "next"
 import { ThemeProvider } from "next-themes"
 import Navbar from "@/components/layout/Navbar"
 import Footer from "@/components/layout/Footer"
-import { siteConfig } from "@/config/site"
+import fs from "fs"
+import path from "path"
 import "./globals.css"
 
 export const metadata: Metadata = {
@@ -35,6 +36,8 @@ export const metadata: Metadata = {
   },
 }
 
+const version = fs.readFileSync(path.resolve(process.cwd(), "../.version"), "utf-8").trim();
+
 const jsonLd = {
   "@context": "https://schema.org",
   "@type": "SoftwareApplication",
@@ -50,7 +53,7 @@ const jsonLd = {
     "Mac virtual machine for secure development. Run isolated macOS workspaces for AI agents, sandboxed code, and untrusted projects.",
   url: "https://ghostvm.org",
   downloadUrl: "https://github.com/groundwater/GhostVM/releases/latest",
-  softwareVersion: siteConfig.version,
+  softwareVersion: version,
   author: {
     "@type": "Organization",
     name: "GhostVM",

--- a/Website/src/config/site.ts
+++ b/Website/src/config/site.ts
@@ -1,16 +1,3 @@
-import fs from "fs";
-import path from "path";
-
-function readVersion(): string {
-  const versionPath = path.resolve(process.cwd(), "../.version");
-  try {
-    return fs.readFileSync(versionPath, "utf-8").trim();
-  } catch {
-    return "unknown";
-  }
-}
-
 export const siteConfig = {
   repo: "https://github.com/groundwater/GhostVM",
-  version: readVersion(),
 };


### PR DESCRIPTION
## Summary

- Remove `fs`/`path` from `site.ts` — it's imported by client components (`DownloadButton`) which can't use Node APIs
- Read `.version` directly in `layout.tsx` (server component) — no try/catch, build fails if file is missing

🤖 Generated with [Claude Code](https://claude.com/claude-code)