### PR TITLE
Add Terminal menu to GhostVMHelper menu bar

### DIFF
--- a/macOS/GhostVMHelper/HelperToolbar.swift
+++ b/macOS/GhostVMHelper/HelperToolbar.swift
@@ -544,7 +544,7 @@ final class HelperToolbar: NSObject, NSToolbarDelegate, NSMenuDelegate, PortForw
         "\(shellEscape(vmctlPath())) shell --name \(shellEscape(vmName))"
     }
 
-    @objc private func openTerminal() {
+    @objc func openTerminal() {
         // AppleScript's `do script` opens a new Terminal window and runs the
         // command in it directly. Cleaner than writing a self-deleting temp
         // script to disk and `open -a Terminal`-ing it.
@@ -564,7 +564,7 @@ final class HelperToolbar: NSObject, NSToolbarDelegate, NSMenuDelegate, PortForw
         try? process.run()
     }
 
-    @objc private func copyVmctlCommand() {
+    @objc func copyVmctlCommand() {
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(vmctlCommand(), forType: .string)
     }

--- a/macOS/GhostVMHelper/main.swift
+++ b/macOS/GhostVMHelper/main.swift
@@ -428,6 +428,31 @@ final class HelperAppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate
         appMenu.addItem(quitItem)
         self.quitMenuItem = quitItem
 
+        // Edit menu (clipboard cross-boundary ops)
+        let editMenuItem = NSMenuItem()
+        editMenuItem.title = "Edit"
+        mainMenu.addItem(editMenuItem)
+        let editMenu = NSMenu(title: "Edit")
+        editMenuItem.submenu = editMenu
+
+        let copyToGuestItem = NSMenuItem(title: "Copy to Guest", action: #selector(copyClipboardToGuest), keyEquivalent: "")
+        copyToGuestItem.target = self
+        editMenu.addItem(copyToGuestItem)
+
+        let copyToHostItem = NSMenuItem(title: "Copy to Host", action: #selector(copyClipboardToHost), keyEquivalent: "")
+        copyToHostItem.target = self
+        editMenu.addItem(copyToHostItem)
+
+        editMenu.addItem(NSMenuItem.separator())
+
+        let syncItem = NSMenuItem(title: "Automatically Sync", action: #selector(toggleClipboardSyncMenu), keyEquivalent: "")
+        syncItem.target = self
+        editMenu.addItem(syncItem)
+
+        let alwaysAllowItem = NSMenuItem(title: "Always Allow", action: #selector(toggleAlwaysAllowClipboard), keyEquivalent: "")
+        alwaysAllowItem.target = self
+        editMenu.addItem(alwaysAllowItem)
+
         // VM menu
         let vmMenuItem = NSMenuItem()
         vmMenuItem.title = "VM"
@@ -438,34 +463,6 @@ final class HelperAppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate
         let startItem = NSMenuItem(title: "Start", action: #selector(startVMAction), keyEquivalent: "r")
         startItem.target = self
         vmMenu.addItem(startItem)
-
-        vmMenu.addItem(NSMenuItem.separator())
-
-        // Clipboard submenu
-        let clipboardMenuItem = NSMenuItem()
-        clipboardMenuItem.title = "Clipboard"
-        let clipboardMenu = NSMenu(title: "Clipboard")
-        clipboardMenuItem.submenu = clipboardMenu
-
-        let copyToGuestItem = NSMenuItem(title: "Copy to Guest", action: #selector(copyClipboardToGuest), keyEquivalent: "")
-        copyToGuestItem.target = self
-        clipboardMenu.addItem(copyToGuestItem)
-
-        let copyToHostItem = NSMenuItem(title: "Copy to Host", action: #selector(copyClipboardToHost), keyEquivalent: "")
-        copyToHostItem.target = self
-        clipboardMenu.addItem(copyToHostItem)
-
-        clipboardMenu.addItem(NSMenuItem.separator())
-
-        let syncItem = NSMenuItem(title: "Automatically Sync", action: #selector(toggleClipboardSyncMenu), keyEquivalent: "")
-        syncItem.target = self
-        clipboardMenu.addItem(syncItem)
-
-        let alwaysAllowItem = NSMenuItem(title: "Always Allow", action: #selector(toggleAlwaysAllowClipboard), keyEquivalent: "")
-        alwaysAllowItem.target = self
-        clipboardMenu.addItem(alwaysAllowItem)
-
-        vmMenu.addItem(clipboardMenuItem)
 
         vmMenu.addItem(NSMenuItem.separator())
 

--- a/macOS/GhostVMHelper/main.swift
+++ b/macOS/GhostVMHelper/main.swift
@@ -482,6 +482,21 @@ final class HelperAppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate
         terminateItem.target = self
         vmMenu.addItem(terminateItem)
 
+        // Terminal menu
+        let terminalMenuItem = NSMenuItem()
+        terminalMenuItem.title = "Terminal"
+        mainMenu.addItem(terminalMenuItem)
+        let terminalMenu = NSMenu(title: "Terminal")
+        terminalMenuItem.submenu = terminalMenu
+
+        let openTerminalItem = NSMenuItem(title: "Open Terminal", action: #selector(openTerminalAction), keyEquivalent: "")
+        openTerminalItem.target = self
+        terminalMenu.addItem(openTerminalItem)
+
+        let copyVmctlItem = NSMenuItem(title: "Copy vmctl Command", action: #selector(copyVmctlCommandAction), keyEquivalent: "")
+        copyVmctlItem.target = self
+        terminalMenu.addItem(copyVmctlItem)
+
         // Window menu
         let windowMenuItem = NSMenuItem()
         windowMenuItem.title = "Window"
@@ -560,6 +575,14 @@ final class HelperAppDelegate: NSObject, NSApplicationDelegate, NSWindowDelegate
                 self?.terminateVM()
             }
         }
+    }
+
+    @objc private func openTerminalAction() {
+        helperToolbar?.openTerminal()
+    }
+
+    @objc private func copyVmctlCommandAction() {
+        helperToolbar?.copyVmctlCommand()
     }
 
     @objc private func toggleClipboardSyncMenu() {


### PR DESCRIPTION
## Summary

Menubar restructuring pass for GhostVMHelper. Two changes:

### 1. New top-level **Terminal** menu

Mirrors the existing Terminal toolbar dropdown so users can find these actions in the menu bar:

- **Open Terminal** — launches Terminal.app running \`vmctl shell --name <VMName>\`
- **Copy vmctl Command** — copies the shell-escaped vmctl command to the pasteboard

Both items forward to the existing \`HelperToolbar.openTerminal()\` / \`copyVmctlCommand()\` implementations (now non-private). No behavior change to the toolbar dropdown.

### 2. Promote Clipboard → top-level **Edit** menu

Clipboard cross-boundary ops are Edit-menu territory in every other Mac app. Moves the existing Clipboard submenu out of VM into a new top-level Edit menu (positioned between the app menu and VM):

\`\`\`
Edit
├── Copy to Guest
├── Copy to Host
├── ──────
├── Automatically Sync     ✓
└── Always Allow           ✓
\`\`\`

VM menu becomes purely lifecycle (Start / Suspend / Shut Down / Terminate). Same selectors and \`validateMenuItem\` rules — pure restructuring.

### Resulting menu bar

\`GhostVM Helper | Edit | VM | Terminal | Window\`

## Test plan

- [ ] \`make debug\` succeeds
- [ ] Launch a VM, confirm menu bar reads: Helper | Edit | VM | Terminal | Window
- [ ] **Terminal → Open Terminal** opens Terminal.app and connects via \`vmctl shell\`
- [ ] **Terminal → Copy vmctl Command** places the correct command on the pasteboard
- [ ] **Edit → Copy to Guest** / **Copy to Host** behave as before
- [ ] **Edit → Automatically Sync** / **Always Allow** show correct checkmark state and toggle
- [ ] VM menu no longer contains a Clipboard submenu

🤖 Generated with [Claude Code](https://claude.com/claude-code)