### PR TITLE
Clone Helper directory in cloneVM so clones are self-contained (#237)

### DIFF
--- a/macOS/GhostVMKit/Operations/VMController.swift
+++ b/macOS/GhostVMKit/Operations/VMController.swift
@@ -584,6 +584,27 @@ public final class VMController {
                 }
             }
 
+            // Clone the Helper directory (per-VM helper app + GhostTools.dmg) so the
+            // clone is self-contained when launched directly via its Dock icon, which
+            // does not re-provision the helper. clonefile() copies directories
+            // recursively on APFS. The helper app bundle is named after the source VM,
+            // so rename it to match the clone (mirrors renameVM()).
+            let sourceHelperDir = sourceLayout.helperDirectoryURL
+            if fileManager.fileExists(atPath: sourceHelperDir.path) {
+                let destHelperDir = newLayout.helperDirectoryURL
+                if Darwin.clonefile(sourceHelperDir.path, destHelperDir.path, 0) == -1 {
+                    let err = String(cString: strerror(errno))
+                    throw VMError.message("Clone failed for Helper directory: \(err). This volume may not support copy-on-write. Move your VMs to an APFS volume.")
+                }
+                let clonedHelperApp = destHelperDir.appendingPathComponent(
+                    sourceLayout.helperAppURL(vmName: sourceName).lastPathComponent)
+                let destHelperApp = newLayout.helperAppURL(vmName: trimmed)
+                if clonedHelperApp.path != destHelperApp.path,
+                   fileManager.fileExists(atPath: clonedHelperApp.path) {
+                    try fileManager.moveItem(at: clonedHelperApp, to: destHelperApp)
+                }
+            }
+
             // Generate fresh identifiers
             let machineIdentifier = VZMacMachineIdentifier()
             try writeData(machineIdentifier.dataRepresentation, to: newLayout.machineIdentifierURL)


### PR DESCRIPTION
Fixes #237.

## Problem

`VMController.cloneVM()` cloned only `disk.img`, `HardwareModel.bin`, and `AuxiliaryStorage.bin`, omitting the per-VM `Helper/` directory (helper app + `GhostTools.dmg`) introduced by the helper-per-VM architecture.

## Severity (corrected from the issue)

The issue states *every clone fails to launch with a "Helper missing" dialog*. That is not what the current code does — both the GUI (`App2VMRuntime.launchHelperApp`) and `vmctl` (`CLI.launchViaHelper`) call `VMHelperBundleManager.copyHelperApp()`, which **re-provisions `Helper/` (helper app + `GhostTools.dmg`) on every launch**. So a clone launched through the main app self-heals.

The real, reproducible defect is narrower: a clone launched **directly via its own Dock icon** does *not* go through `copyHelperApp`. `VMConfigurationBuilder.findGhostToolsDMG()` then looks for the sibling `Helper/GhostTools.dmg`, which the clone never received — so the VM boots with **guest tools silently unavailable** (clipboard, file transfer, port forwarding, icon mode). On `v3-dev` the `skipHelperCopy` legacy-migration-decline path can also surface `"Helper app not found in VM bundle"`.

Regardless of severity, a clone should be self-contained, so we copy `Helper/` at clone time.

## Fix

Clone the `Helper/` directory via `clonefile()` (recursive copy-on-write on APFS, consistent with the existing file clones) and rename the helper `.app` bundle from the source VM name to the clone's name — mirroring the rename logic already in `renameVM()`.

## Notes

- Independent implementation using our own `VMFileLayout` API; does not pull the external fork's patch/branch.
- `make framework` (GhostVMKit) builds cleanly.
- A sibling PR will port this to `main` (v2), which has the same `cloneVM` omission.

🤖 Generated with [Claude Code](https://claude.com/claude-code)