### PR TITLE
Clone Helper directory in cloneVM so clones are self-contained (v2)

### DIFF
--- a/macOS/GhostVMKit/Operations/VMController.swift
+++ b/macOS/GhostVMKit/Operations/VMController.swift
@@ -576,6 +576,27 @@ public final class VMController {
                 }
             }
 
+            // Clone the Helper directory (per-VM helper app + GhostTools.dmg) so the
+            // clone is self-contained when launched directly via its Dock icon, which
+            // does not re-provision the helper. clonefile() copies directories
+            // recursively on APFS. The helper app bundle is named after the source VM,
+            // so rename it to match the clone (mirrors renameVM()).
+            let sourceHelperDir = sourceLayout.helperDirectoryURL
+            if fileManager.fileExists(atPath: sourceHelperDir.path) {
+                let destHelperDir = newLayout.helperDirectoryURL
+                if Darwin.clonefile(sourceHelperDir.path, destHelperDir.path, 0) == -1 {
+                    let err = String(cString: strerror(errno))
+                    throw VMError.message("Clone failed for Helper directory: \(err). This volume may not support copy-on-write. Move your VMs to an APFS volume.")
+                }
+                let clonedHelperApp = destHelperDir.appendingPathComponent(
+                    sourceLayout.helperAppURL(vmName: sourceName).lastPathComponent)
+                let destHelperApp = newLayout.helperAppURL(vmName: trimmed)
+                if clonedHelperApp.path != destHelperApp.path,
+                   fileManager.fileExists(atPath: clonedHelperApp.path) {
+                    try fileManager.moveItem(at: clonedHelperApp, to: destHelperApp)
+                }
+            }
+
             // Generate fresh identifiers
             let machineIdentifier = VZMacMachineIdentifier()
             try writeData(machineIdentifier.dataRepresentation, to: newLayout.machineIdentifierURL)


### PR DESCRIPTION
v2 (main) port of #238 — see #237.

## Problem

`VMController.cloneVM()` cloned only `disk.img`, `HardwareModel.bin`, and `AuxiliaryStorage.bin`, omitting the per-VM `Helper/` directory (helper app + `GhostTools.dmg`). The same omission exists on `main` as on `v3-dev`.

## Severity note (v2-specific)

On `main` there is **no `skipHelperCopy` path** — the launch path *always* calls `copyHelperApp()`, so a clone launched through the main app always self-heals. The residual defect is the **direct Dock-icon launch**, which does not re-provision and therefore boots without `Helper/GhostTools.dmg` → guest tools silently unavailable. A clone should be self-contained regardless.

## Fix

Clone `Helper/` via `clonefile()` (recursive COW on APFS) and rename the helper `.app` to the clone's name, mirroring `renameVM()`. Cherry-picked from the `v3-dev` fix (#238).

`make framework` builds cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)