### PR TITLE
Add vmctl suspend and clone commands (#235, #236)

### DIFF
--- a/macOS/GhostVM/vmctl/CLI.swift
+++ b/macOS/GhostVM/vmctl/CLI.swift
@@ -45,6 +45,12 @@ struct CLI {
             } catch {
                 fail(error)
             }
+        case "suspend":
+            do {
+                try handleSuspend(arguments: Array(arguments.dropFirst()))
+            } catch {
+                fail(error)
+            }
         case "status":
             do {
                 try handleStatus(arguments: Array(arguments.dropFirst()))
@@ -66,6 +72,12 @@ struct CLI {
         case "discard-suspend":
             do {
                 try handleDiscardSuspend(arguments: Array(arguments.dropFirst()))
+            } catch {
+                fail(error)
+            }
+        case "clone":
+            do {
+                try handleClone(arguments: Array(arguments.dropFirst()))
             } catch {
                 fail(error)
             }
@@ -259,6 +271,23 @@ struct CLI {
         }
         let bundleURL = try resolveBundleURL(argument: bundleArg, mustExist: true)
         try controller.stopVM(bundleURL: bundleURL)
+    }
+
+    private func handleSuspend(arguments: [String]) throws {
+        guard let bundleArg = arguments.first else {
+            throw VMError.message("Usage: vmctl suspend <bundle-path>")
+        }
+        let bundleURL = try resolveBundleURL(argument: bundleArg, mustExist: true)
+        try controller.suspendVM(bundleURL: bundleURL)
+    }
+
+    private func handleClone(arguments: [String]) throws {
+        guard arguments.count >= 2 else {
+            throw VMError.message("Usage: vmctl clone <source-bundle-path> <new-name>")
+        }
+        let bundleURL = try resolveBundleURL(argument: arguments[0], mustExist: true)
+        let newURL = try controller.cloneVM(bundleURL: bundleURL, newName: arguments[1])
+        print("Cloned '\(controller.displayName(for: bundleURL))' to '\(newURL.path)' (APFS copy-on-write).")
     }
 
     private func handleStatus(arguments: [String]) throws {
@@ -469,9 +498,11 @@ Commands:
   install <bundle-path>
   start <bundle-path> [--headless] [--shared-folder PATH] [--writable|--read-only]
   stop <bundle-path>
+  suspend <bundle-path>
   status <bundle-path>
   resume <bundle-path> [--headless] [--shared-folder PATH] [--writable|--read-only]
   discard-suspend <bundle-path>
+  clone <source-bundle-path> <new-name>  Clone a VM (APFS copy-on-write, instant)
   snapshot <bundle-path> list
   snapshot <bundle-path> <create|revert|delete> <snapshot-name>
   shell --name <VMName> [--command /bin/bash]  Interactive terminal on guest
@@ -495,9 +526,11 @@ Examples:
   vmctl start ~/VMs/sandbox.GhostVM --headless         # headless (SSH after setup)
   vmctl start ~/VMs/sandbox.GhostVM --shared-folder ~/Projects --writable
   vmctl stop ~/VMs/sandbox.GhostVM
+  vmctl suspend ~/VMs/sandbox.GhostVM                  # Save state and suspend
   vmctl status ~/VMs/sandbox.GhostVM
   vmctl resume ~/VMs/sandbox.GhostVM                   # Resume from suspended state
   vmctl discard-suspend ~/VMs/sandbox.GhostVM          # Discard suspended state
+  vmctl clone ~/VMs/sandbox.GhostVM sandbox-clone      # Clone VM (instant, APFS COW)
   vmctl snapshot ~/VMs/sandbox.GhostVM list
   vmctl snapshot ~/VMs/sandbox.GhostVM create clean
   vmctl snapshot ~/VMs/sandbox.GhostVM revert clean
@@ -513,7 +546,6 @@ Examples:
 Notes:
   - After installation, enable Remote Login (SSH) inside the guest for convenient headless access.
   - Apple's EULA requires macOS guests to run on Apple-branded hardware.
-  - Use Virtual Machine > Suspend menu (Cmd+S) to suspend a running VM.
 """
         print(help)
         exit(exitCode)

--- a/macOS/GhostVMKit/Operations/VMController.swift
+++ b/macOS/GhostVMKit/Operations/VMController.swift
@@ -1048,6 +1048,51 @@ public final class VMController {
         try discardSuspend(bundleURL: bundleURL(for: name))
     }
 
+    /// Suspend a running helper-backed VM by asking its helper process to save state.
+    /// Reuses the existing `com.ghostvm.helper.suspend.<hash>` notification that the
+    /// helper already listens for, then blocks until the helper exits and the saved
+    /// suspend state is verified on disk.
+    public func suspendVM(bundleURL: URL, timeout: TimeInterval = 300) throws {
+        let standardized = bundleURL.standardizedFileURL
+        let layout = try layoutForExistingBundle(at: standardized)
+        let entry = try loadEntry(for: standardized)
+        let vmName = displayName(for: standardized)
+
+        guard let pid = entry.runningPID else {
+            print(entry.isSuspended ? "VM '\(vmName)' is already suspended." : "VM '\(vmName)' does not appear to be running.")
+            return
+        }
+
+        let bundlePathHash = standardized.path.stableHash
+        print("Sending suspend request to VM '\(vmName)' (PID \(pid)).")
+        DistributedNotificationCenter.default().postNotificationName(
+            NSNotification.Name("com.ghostvm.helper.suspend.\(bundlePathHash)"),
+            object: nil,
+            userInfo: nil,
+            deliverImmediately: true
+        )
+
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if kill(pid, 0) != 0 {
+                let config = try VMConfigStore(layout: layout).load()
+                guard config.isSuspended, fileManager.fileExists(atPath: layout.suspendStateURL.path) else {
+                    throw VMError.message("VM '\(vmName)' exited before saving suspended state.")
+                }
+                removeVMLock(at: layout.pidFileURL)
+                print("VM '\(vmName)' suspended.")
+                return
+            }
+            Thread.sleep(forTimeInterval: 1)
+        }
+
+        throw VMError.message("Timed out waiting for VM '\(vmName)' to suspend.")
+    }
+
+    public func suspendVM(name: String, timeout: TimeInterval = 300) throws {
+        try suspendVM(bundleURL: bundleURL(for: name), timeout: timeout)
+    }
+
     // MARK: - CLI Start/Resume (blocking)
 
     /// Start a VM from the CLI. Blocks until the VM terminates.


### PR DESCRIPTION
Closes #235. Closes #236.

Adds two missing `vmctl` subcommands for CLI parity with the GUI and headless/scripted workflows.

## `vmctl suspend <bundle-path>` (#235)

`vmctl` already had `resume` and `discard-suspend` but no `suspend`. Adds `VMController.suspendVM(bundleURL:)` which:

- looks up the running helper PID via `loadEntry`,
- posts the **existing** `com.ghostvm.helper.suspend.<hash>` distributed notification that `GhostVMHelper` already listens for (`main.swift:1225`) — no new helper behavior,
- blocks until the helper exits, then verifies `config.isSuspended` + the saved `suspend.vzvmsave` exists before clearing the lock.

Hash derivation matches the helper exactly (`standardizedFileURL.path.stableHash`).

## `vmctl clone <source-bundle-path> <new-name>` (#236)

Wires the CLI to the existing `VMController.cloneVM()` (APFS copy-on-write, fresh `VZMacMachineIdentifier` + MAC, cleared per-instance config) — the same path the GUI uses, recently hardened by #237/#238. Clone is placed beside the source; source must be installed and stopped.

## Help text

Adds both commands to the Commands + Examples sections and removes the now-stale note telling CLI users to suspend via the GUI menu.

## Notes / verification

- Implemented against our own GhostVMKit API after verifying every symbol and the helper listener; does not apply the reporter's fork patches verbatim.
- `make framework` and `xcodebuild -scheme vmctl CODE_SIGNING_ALLOWED=NO` both build clean. (Full signed `vmctl` build needs a dev team, so end-to-end runtime test of suspend/clone is left for a local signed build.)
- Targeted at `v3-dev` (active line). Can port to `main`/v2 if CLI parity there is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)