### PR TITLE
Allow cloning a VM while it is running (#140)

### DIFF
--- a/macOS/GhostVM/SwiftUIDemoApp.swift
+++ b/macOS/GhostVM/SwiftUIDemoApp.swift
@@ -2072,7 +2072,7 @@ struct VMContextMenu: View {
         Button("Clone…") {
             requestClone()
         }
-        .disabled(isRunning || !vm.installed)
+        .disabled(!vm.installed)
 
         Divider()
 

--- a/macOS/GhostVMKit/Operations/VMController.swift
+++ b/macOS/GhostVMKit/Operations/VMController.swift
@@ -549,10 +549,11 @@ public final class VMController {
             throw VMError.message("VM '\(sourceName)' is not installed. Only installed VMs can be cloned.")
         }
 
-        // Source must not be running
-        guard !isVMProcessRunning(layout: sourceLayout) else {
-            throw VMError.message("VM '\(sourceName)' is running. Stop it before cloning.")
-        }
+        // Cloning a running VM is allowed. clonefile() produces a crash-consistent
+        // copy of the disk (equivalent to sudden power loss), which macOS recovers
+        // from on boot via its journaled filesystem. The clone also gets a fresh
+        // machine identifier, MAC address, and cleared per-instance state below, so
+        // there is no identity collision or state leakage with the running source.
 
         // Create new bundle in the same parent directory
         let parentDir = bundleURL.deletingLastPathComponent()


### PR DESCRIPTION
Part of #140 (v3 line; sibling PR targets `main`/v2).

## What

Removes the restriction that a VM must be stopped before cloning:

1. **`VMController.cloneVM()`** — drop the `isVMProcessRunning` guard (covers both GUI and `vmctl clone` callers).
2. **`SwiftUIDemoApp.swift`** — drop `isRunning` from the Clone button's `.disabled()` condition.

The `installed` requirement is unchanged.

## Why it's safe

`clonefile()` is a filesystem-level copy-on-write, producing a **crash-consistent** disk image (equivalent to sudden power loss) that macOS recovers from on boot via its journaled filesystem. The clone already gets a fresh `VZMacMachineIdentifier`, a new MAC, cleared shared folders / port forwards / snapshots, and `isSuspended:false` — no identity collision or state leakage with the running source.

## Verification

- `make framework` (GhostVMKit) and the `GhostVM` app target (signing-disabled) both build clean.
- Runtime test (clone a live VM, confirm crash-consistent boot) left for a local signed build — the engine change is a guard removal on the already-validated `cloneVM` path.

Implemented from scratch against current `v3-dev`; does not apply the external fork patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)