### PR TITLE
Allow cloning a VM while it is running (v2)

### DIFF
--- a/macOS/GhostVM/SwiftUIDemoApp.swift
+++ b/macOS/GhostVM/SwiftUIDemoApp.swift
@@ -2072,7 +2072,7 @@ struct VMContextMenu: View {
         Button("Clone…") {
             requestClone()
         }
-        .disabled(isRunning || !vm.installed)
+        .disabled(!vm.installed)
 
         Divider()
 

--- a/macOS/GhostVMKit/Operations/VMController.swift
+++ b/macOS/GhostVMKit/Operations/VMController.swift
@@ -541,10 +541,11 @@ public final class VMController {
             throw VMError.message("VM '\(sourceName)' is not installed. Only installed VMs can be cloned.")
         }
 
-        // Source must not be running
-        guard !isVMProcessRunning(layout: sourceLayout) else {
-            throw VMError.message("VM '\(sourceName)' is running. Stop it before cloning.")
-        }
+        // Cloning a running VM is allowed. clonefile() produces a crash-consistent
+        // copy of the disk (equivalent to sudden power loss), which macOS recovers
+        // from on boot via its journaled filesystem. The clone also gets a fresh
+        // machine identifier, MAC address, and cleared per-instance state below, so
+        // there is no identity collision or state leakage with the running source.
 
         // Create new bundle in the same parent directory
         let parentDir = bundleURL.deletingLastPathComponent()


### PR DESCRIPTION
Closes #140. v2 (main) port of #241.

Removes the requirement that a VM be stopped before cloning:

1. **`VMController.cloneVM()`** — drop the `isVMProcessRunning` guard (covers GUI and `vmctl` callers).
2. **`SwiftUIDemoApp.swift`** — drop `isRunning` from the Clone button's `.disabled()` condition.

**Why it's safe:** `clonefile()` is filesystem-level copy-on-write → a crash-consistent disk image (like sudden power loss) that macOS recovers on boot. The clone already gets a fresh machine identifier, MAC, cleared shared folders/port forwards/snapshots, and `isSuspended:false` — no identity collision or state leakage.

Cherry-picked from #241. `make framework` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)