### PR TITLE
Update appcast for v2.11.0

### DIFF
--- a/Website/public/appcast.xml
+++ b/Website/public/appcast.xml
@@ -22,6 +22,20 @@
     </item>
     -->
     <item>
+      <title>GhostVM 2.11.0</title>
+      <pubDate>Thu, 16 Apr 2026 12:34:16 -0700</pubDate>
+      <sparkle:version>2.11.0</sparkle:version>
+      <sparkle:shortVersionString>2.11.0</sparkle:shortVersionString>
+      <sparkle:minimumSystemVersion>15.0</sparkle:minimumSystemVersion>
+      <description><![CDATA[<ul><li>Fix --headless flag and add vmctl entitlements for headless VM support</li></ul>]]></description>
+      <enclosure
+        url="https://github.com/groundwater/GhostVM/releases/download/v2.11.0/GhostVM-2.11.0.dmg"
+        type="application/octet-stream"
+        sparkle:edSignature="rba3YXg29rSs//yoh/YzwrUhg+2c3Qrd9qiIbX/ipBMqHHJsbnz/aMhq6NyKTslS3fDQx8/uqIto9W6ZHlBADA=="
+        length="32398124"
+      />
+    </item>
+    <item>
       <title>GhostVM 2.10.0</title>
       <pubDate>Mon, 13 Apr 2026 23:44:17 -0700</pubDate>
       <sparkle:version>2.10.0</sparkle:version>


### PR DESCRIPTION
Add Sparkle update feed entry for v2.11.0.

Closes #243

Signature generated with Sparkle's `sign_update` against the released DMG (verified: size 32398124, sha256 `c974493ca79cf8c0071dbb72da39cedd5e35ab87f19cbd72de542989e619432d`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)